### PR TITLE
#4.7 Password Screen

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-  "workbench.colorTheme": "Default High Contrast"
-}

--- a/lib/features/authentication/birthday_screen.dart
+++ b/lib/features/authentication/birthday_screen.dart
@@ -1,0 +1,10 @@
+import 'package:flutter/material.dart';
+
+class BirthdayScreen extends StatelessWidget {
+  const BirthdayScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold();
+  }
+}

--- a/lib/features/authentication/email_screen.dart
+++ b/lib/features/authentication/email_screen.dart
@@ -95,7 +95,7 @@ class _EmailScreenState extends State<EmailScreen> {
                 ),
                 cursorColor: Theme.of(context).primaryColor,
               ),
-              Gaps.v16,
+              Gaps.v28,
               GestureDetector(
                 onTap: _onSubmit,
                 child: FormButton(

--- a/lib/features/authentication/password_screen.dart
+++ b/lib/features/authentication/password_screen.dart
@@ -1,10 +1,155 @@
 import 'package:flutter/material.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
+import 'package:tiktong/constants/gaps.dart';
+import 'package:tiktong/constants/sizes.dart';
+import 'package:tiktong/features/authentication/birthday_screen.dart';
+import 'package:tiktong/features/authentication/widgets/form_button.dart';
 
-class PasswordScreen extends StatelessWidget {
+class PasswordScreen extends StatefulWidget {
   const PasswordScreen({super.key});
 
   @override
+  State<PasswordScreen> createState() => _PasswordScreenState();
+}
+
+class _PasswordScreenState extends State<PasswordScreen> {
+  final TextEditingController _passwordController = TextEditingController();
+
+  String _password = "";
+
+  bool _obscureText = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _passwordController.addListener(() {
+      setState(() {
+        _password = _passwordController.text;
+      });
+    });
+  }
+
+  @override
+  void dispose() {
+    _passwordController.dispose();
+    super.dispose();
+  }
+
+  bool _isPasswordValid() {
+    return _password.isNotEmpty && _password.length > 8;
+  }
+
+  void _onScaffoldTap() {
+    FocusScope.of(context).unfocus();
+  }
+
+  void _onSubmit() {
+    if (!_isPasswordValid()) return;
+    Navigator.push(
+      context,
+      MaterialPageRoute(builder: (context) => BirthdayScreen()),
+    );
+  }
+
+  void _onClearTab() {
+    _passwordController.clear();
+  }
+
+  void _toggleObscureText() {
+    setState(() {
+      _obscureText = !_obscureText;
+    });
+  }
+
+  @override
   Widget build(BuildContext context) {
-    return const Scaffold();
+    return GestureDetector(
+      onTap: _onScaffoldTap,
+      child: Scaffold(
+        appBar: AppBar(title: Text("Sign up")),
+        body: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: Sizes.size36),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Gaps.v40,
+              Text(
+                "Password",
+                style: TextStyle(
+                  fontSize: Sizes.size24,
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+              Gaps.v16,
+              TextField(
+                controller: _passwordController,
+                onEditingComplete: _onSubmit,
+                obscureText: _obscureText,
+                autocorrect: false,
+                decoration: InputDecoration(
+                  suffix: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      GestureDetector(
+                        onTap: _onClearTab,
+                        child: FaIcon(
+                          FontAwesomeIcons.solidCircleXmark,
+                          color: Colors.grey.shade400,
+                          size: Sizes.size20,
+                        ),
+                      ),
+                      Gaps.h16,
+                      GestureDetector(
+                        onTap: _toggleObscureText,
+                        child: FaIcon(
+                          _obscureText
+                              ? FontAwesomeIcons.eye
+                              : FontAwesomeIcons.eyeSlash,
+                          color: Colors.grey.shade400,
+                          size: Sizes.size20,
+                        ),
+                      ),
+                    ],
+                  ),
+                  hintText: "Password",
+                  enabledBorder: UnderlineInputBorder(
+                    borderSide: BorderSide(color: Colors.grey[400]!),
+                  ),
+                  focusedBorder: UnderlineInputBorder(
+                    borderSide: BorderSide(color: Colors.grey[400]!),
+                  ),
+                ),
+                cursorColor: Theme.of(context).primaryColor,
+              ),
+              Gaps.v10,
+              const Text(
+                'Your password must have:',
+                style: TextStyle(fontWeight: FontWeight.bold),
+              ),
+              Gaps.v10,
+              Row(
+                children: [
+                  FaIcon(
+                    FontAwesomeIcons.circleCheck,
+                    size: Sizes.size20,
+                    color:
+                        _isPasswordValid()
+                            ? Colors.green
+                            : Colors.grey.shade400,
+                  ),
+                  Gaps.h5,
+                  const Text("8 to 20 characters"),
+                ],
+              ),
+              Gaps.v28,
+              GestureDetector(
+                onTap: _onSubmit,
+                child: FormButton(disabled: !_isPasswordValid()),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
   }
 }


### PR DESCRIPTION
## Password Screen

### 화면
![Image](https://github.com/user-attachments/assets/53487020-c45d-4e49-87de-56cc69191bd3)

### 작업 내역
- [x] Validation ( 8 ~ 20 )자 적용
- [x] 입력 값 제거 기능 구현
- [x] 비밀번호처럼 보이게 하는 기능 구현
- [x] 눈 아이콘을 누르면 입력된 비밀번호 확인 기능 구현
- [x] 비밀번호 입력 폼 제출 시 BirthdayScreen 으로 넘어가도록 기능 구현