### PR TITLE
#4.8 Birthday Screen

### DIFF
--- a/lib/features/authentication/birthday_screen.dart
+++ b/lib/features/authentication/birthday_screen.dart
@@ -1,10 +1,103 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:tiktong/constants/gaps.dart';
+import 'package:tiktong/constants/sizes.dart';
+import 'package:tiktong/features/onboarding/interests_screen.dart';
+import 'package:tiktong/features/authentication/widgets/form_button.dart';
 
-class BirthdayScreen extends StatelessWidget {
+class BirthdayScreen extends StatefulWidget {
   const BirthdayScreen({super.key});
 
   @override
+  State<BirthdayScreen> createState() => _BirthdayScreenState();
+}
+
+class _BirthdayScreenState extends State<BirthdayScreen> {
+  final TextEditingController _birthdayController = TextEditingController();
+
+  DateTime initialDate = DateTime(
+    DateTime.now().year - 12,
+    DateTime.now().month,
+    DateTime.now().day,
+  );
+
+  @override
+  void initState() {
+    super.initState();
+    _setTextFieldDate(initialDate);
+  }
+
+  @override
+  void dispose() {
+    _birthdayController.dispose();
+    super.dispose();
+  }
+
+  void _onNextTap() {
+    Navigator.of(
+      context,
+    ).push(MaterialPageRoute(builder: (context) => const InterestsScreen()));
+  }
+
+  void _setTextFieldDate(DateTime date) {
+    final textDate = date.toString().split(" ").first;
+    _birthdayController.value = TextEditingValue(text: textDate);
+  }
+
+  @override
   Widget build(BuildContext context) {
-    return const Scaffold();
+    return Scaffold(
+      appBar: AppBar(title: Text("Sign up")),
+      body: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: Sizes.size36),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Gaps.v40,
+            Text(
+              "When's your birthday?",
+              style: TextStyle(
+                fontSize: Sizes.size24,
+                fontWeight: FontWeight.w700,
+              ),
+            ),
+            Gaps.v10,
+            Text(
+              "Your birthday won't be shown publicly.",
+              style: TextStyle(fontSize: Sizes.size16, color: Colors.black54),
+            ),
+            Gaps.v16,
+            TextField(
+              readOnly: true,
+              controller: _birthdayController,
+              decoration: InputDecoration(
+                enabledBorder: UnderlineInputBorder(
+                  borderSide: BorderSide(color: Colors.grey[400]!),
+                ),
+                focusedBorder: UnderlineInputBorder(
+                  borderSide: BorderSide(color: Colors.grey[400]!),
+                ),
+              ),
+              cursorColor: Theme.of(context).primaryColor,
+            ),
+            Gaps.v16,
+            GestureDetector(
+              onTap: _onNextTap,
+              child: FormButton(disabled: false),
+            ),
+          ],
+        ),
+      ),
+      bottomNavigationBar: BottomAppBar(
+        color: Colors.white,
+        height: 300,
+        child: CupertinoDatePicker(
+          maximumDate: initialDate,
+          initialDateTime: initialDate,
+          mode: CupertinoDatePickerMode.date,
+          onDateTimeChanged: _setTextFieldDate,
+        ),
+      ),
+    );
   }
 }

--- a/lib/features/authentication/login_form_screen.dart
+++ b/lib/features/authentication/login_form_screen.dart
@@ -1,0 +1,10 @@
+import 'package:flutter/material.dart';
+
+class LoginFormScreen extends StatelessWidget {
+  const LoginFormScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold();
+  }
+}

--- a/lib/features/onboarding/interests_screen.dart
+++ b/lib/features/onboarding/interests_screen.dart
@@ -1,0 +1,10 @@
+import 'package:flutter/material.dart';
+
+class InterestsScreen extends StatelessWidget {
+  const InterestsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold();
+  }
+}


### PR DESCRIPTION
## 4.8 Birthday Screen

### 화면
<img width="1353" alt="Image" src="https://github.com/user-attachments/assets/f468503c-e479-46b9-9d50-e77cfff63e15" />

### 작업 내역
- [x] 날짜 입력 폼 추가
- [x] 날짜 입력 시 `CupertinoDatePicker`위젯으로만 입력할 수 있도록 기능 구현
- [x] 온보딩 폴더 추가
- [x] `login_form_screen.dart`파일 추가