### PR TITLE
#6.5 Custom Navigation Bar

### DIFF
--- a/lib/features/main_navigation/main_navigation_screen.dart
+++ b/lib/features/main_navigation/main_navigation_screen.dart
@@ -1,6 +1,7 @@
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:tiktong/constants/sizes.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
+import 'package:tiktong/features/main_navigation/widgets/nav_tab.dart';
 
 class MainNavigationScreen extends StatefulWidget {
   const MainNavigationScreen({super.key});
@@ -28,20 +29,45 @@ class _MainNavigationScreenState extends State<MainNavigationScreen> {
 
   @override
   Widget build(BuildContext context) {
-    return CupertinoTabScaffold(
-      tabBar: CupertinoTabBar(
-        items: [
-          BottomNavigationBarItem(
-            icon: Icon(CupertinoIcons.house),
-            label: "Home",
+    return Scaffold(
+      bottomNavigationBar: BottomAppBar(
+        color: Colors.black,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: Sizes.size12),
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              NavTab(
+                text: "Home",
+                isSelected: _selectedIndex == 0,
+                icon: FontAwesomeIcons.house,
+                onTap: () => _onTap(0),
+              ),
+
+              NavTab(
+                text: "Discover",
+                isSelected: _selectedIndex == 1,
+                icon: FontAwesomeIcons.magnifyingGlass,
+                onTap: () => _onTap(1),
+              ),
+
+              NavTab(
+                text: "Inbox",
+                isSelected: _selectedIndex == 3,
+                icon: FontAwesomeIcons.message,
+                onTap: () => _onTap(3),
+              ),
+
+              NavTab(
+                text: "Profile",
+                isSelected: _selectedIndex == 4,
+                icon: FontAwesomeIcons.user,
+                onTap: () => _onTap(4),
+              ),
+            ],
           ),
-          BottomNavigationBarItem(
-            icon: Icon(CupertinoIcons.search),
-            label: "Search",
-          ),
-        ],
+        ),
       ),
-      tabBuilder: (context, index) => screens[index],
     );
   }
 }

--- a/lib/features/main_navigation/widgets/nav_tab.dart
+++ b/lib/features/main_navigation/widgets/nav_tab.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+import 'package:tiktong/constants/gaps.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
+
+class NavTab extends StatelessWidget {
+  const NavTab({
+    super.key,
+    required this.text,
+    required this.icon,
+    required this.onTap,
+    required this.isSelected,
+  });
+
+  final String text;
+  final IconData icon;
+  final Function onTap;
+  final bool isSelected;
+
+  @override
+  Widget build(BuildContext context) {
+    return Expanded(
+      child: GestureDetector(
+        onTap: () => onTap(),
+        child: Container(
+          color: Colors.transparent,
+          child: AnimatedOpacity(
+            duration: Duration(milliseconds: 300),
+            opacity: isSelected ? 1 : 0.6,
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                FaIcon(icon, color: Colors.white),
+                Gaps.v5,
+                Text(text, style: TextStyle(color: Colors.white)),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## 6.5 Custom Navigation Bar

### 화면
<img width="1349" alt="Image" src="https://github.com/user-attachments/assets/46293fbb-d811-4dda-9e80-5262d886fa23" />

### 작업 내역
- [x] `GestureDetector`위젯을 `Expanded`위젯으로 감싸서 클릭 범위 동일하게 기능 구현
- [x] Navigation 아이템들을 공통 위젯으로 만들어서 `nav_tab.dart`파일로 분리