### PR TITLE
#6.7 Stateful Navigation Part Two

### DIFF
--- a/lib/features/main_navigation/main_navigation_screen.dart
+++ b/lib/features/main_navigation/main_navigation_screen.dart
@@ -14,14 +14,6 @@ class MainNavigationScreen extends StatefulWidget {
 class _MainNavigationScreenState extends State<MainNavigationScreen> {
   int _selectedIndex = 0;
 
-  final screens = [
-    StfScreen(key: GlobalKey()),
-    StfScreen(key: GlobalKey()),
-    Container(),
-    StfScreen(key: GlobalKey()),
-    StfScreen(key: GlobalKey()),
-  ];
-
   void _onTap(int index) {
     setState(() {
       _selectedIndex = index;
@@ -31,7 +23,14 @@ class _MainNavigationScreenState extends State<MainNavigationScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      body: screens.elementAt(_selectedIndex),
+      body: Stack(
+        children: [
+          Offstage(offstage: _selectedIndex != 0, child: StfScreen()),
+          Offstage(offstage: _selectedIndex != 1, child: StfScreen()),
+          Offstage(offstage: _selectedIndex != 3, child: StfScreen()),
+          Offstage(offstage: _selectedIndex != 4, child: StfScreen()),
+        ],
+      ),
 
       bottomNavigationBar: BottomAppBar(
         color: Colors.black,


### PR DESCRIPTION
## 6.7 Stateful Navigation Part Two

### 화면
<img width="1346" alt="Image" src="https://github.com/user-attachments/assets/79a020ec-142d-4122-ba85-811abebf50c1" />

### 작업 내역
- [x] Navigation Tab이 변경되면 이전 Screen이 보이지 않도록 `Offstage`위젯을 통해 설정