### PR TITLE
#8.0 showModalBottomSheet

### DIFF
--- a/lib/features/videos/widgets/video_comments.dart
+++ b/lib/features/videos/widgets/video_comments.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/material.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
+import 'package:tiktong/constants/sizes.dart';
+
+class VideoComments extends StatefulWidget {
+  const VideoComments({super.key});
+
+  @override
+  State<VideoComments> createState() => _VideoCommentsState();
+}
+
+class _VideoCommentsState extends State<VideoComments> {
+  void _onClosePressed() {
+    Navigator.of(context).pop();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      clipBehavior: Clip.hardEdge,
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(Sizes.size14),
+      ),
+      child: Scaffold(
+        backgroundColor: Colors.grey.shade50,
+        appBar: AppBar(
+          backgroundColor: Colors.grey.shade50,
+          automaticallyImplyLeading: false,
+          title: const Text("22796 comments"),
+          actions: [
+            IconButton(
+              onPressed: _onClosePressed,
+              icon: FaIcon(FontAwesomeIcons.xmark),
+            ),
+          ],
+        ),
+        body: ListView.builder(
+          itemCount: 10,
+          itemBuilder:
+              (context, index) => Container(child: const Text("im a comment")),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/videos/widgets/video_post.dart
+++ b/lib/features/videos/widgets/video_post.dart
@@ -3,6 +3,7 @@ import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:tiktong/constants/gaps.dart';
 import 'package:tiktong/constants/sizes.dart';
 import 'package:tiktong/features/videos/widgets/video_button.dart';
+import 'package:tiktong/features/videos/widgets/video_comments.dart';
 import 'package:video_player/video_player.dart';
 import 'package:visibility_detector/visibility_detector.dart';
 
@@ -93,6 +94,20 @@ class _VideoPostState extends State<VideoPost>
     });
   }
 
+  void _onCommentsTap(BuildContext context) async {
+    // 영상이 재생중이면 일시정지
+    if (_videoPlayerController.value.isPlaying) {
+      _onTogglePause();
+    }
+
+    await showModalBottomSheet(
+      context: context,
+      backgroundColor: Colors.transparent,
+      builder: (context) => const VideoComments(),
+    );
+    _onTogglePause();
+  }
+
   @override
   Widget build(BuildContext context) {
     return VisibilityDetector(
@@ -161,7 +176,7 @@ class _VideoPostState extends State<VideoPost>
             bottom: 20,
             right: 10,
             child: Column(
-              children: const [
+              children: [
                 CircleAvatar(
                   radius: 25,
                   backgroundColor: Colors.deepPurple,
@@ -180,7 +195,13 @@ class _VideoPostState extends State<VideoPost>
                 Gaps.v24,
                 VideoButton(icon: FontAwesomeIcons.solidHeart, text: "2.9M"),
                 Gaps.v24,
-                VideoButton(icon: FontAwesomeIcons.solidComment, text: "33K"),
+                GestureDetector(
+                  onTap: () => _onCommentsTap(context),
+                  child: VideoButton(
+                    icon: FontAwesomeIcons.solidComment,
+                    text: "33K",
+                  ),
+                ),
                 Gaps.v24,
                 VideoButton(icon: FontAwesomeIcons.share, text: "Share"),
               ],

--- a/lib/features/videos/widgets/video_post.dart
+++ b/lib/features/videos/widgets/video_post.dart
@@ -73,7 +73,9 @@ class _VideoPostState extends State<VideoPost>
   }
 
   void _onVisibilityChanged(VisibilityInfo info) {
-    if (info.visibleFraction == 1 && !_videoPlayerController.value.isPlaying) {
+    if (info.visibleFraction == 1 &&
+        !_isPaused &&
+        !_videoPlayerController.value.isPlaying) {
       _videoPlayerController.play();
     }
   }


### PR DESCRIPTION
## 8.0 showModalBottomSheet

### 화면
<img width="1347" alt="Image" src="https://github.com/user-attachments/assets/4aece2ea-a2c4-43db-8d5c-0c3cb41bf1ff" />

### 작업 내역 
- [x] `VisibilityDetector`위젯 오류( Refresh indicator 시 재생 ) 수정
- [x] `showModalBottomSheet`을 이용해서 댓글 아이콘 클릭 시 Sheet가 열리도록 설정
- [x] `ListView`의 builder를 이용해서 List 출력