### PR TITLE
#9.1 Light Navigation

### DIFF
--- a/lib/features/discover/discover_screen.dart
+++ b/lib/features/discover/discover_screen.dart
@@ -1,0 +1,10 @@
+import 'package:flutter/material.dart';
+
+class DiscoverScreen extends StatelessWidget {
+  const DiscoverScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(appBar: AppBar(title: const Text("Discover")));
+  }
+}

--- a/lib/features/main_navigation/main_navigation_screen.dart
+++ b/lib/features/main_navigation/main_navigation_screen.dart
@@ -48,7 +48,7 @@ class _MainNavigationScreenState extends State<MainNavigationScreen> {
       ),
 
       bottomNavigationBar: BottomAppBar(
-        color: Colors.black,
+        color: _selectedIndex == 0 ? Colors.black : Colors.white,
         child: Padding(
           padding: const EdgeInsets.symmetric(horizontal: Sizes.size12),
           child: Row(
@@ -60,6 +60,7 @@ class _MainNavigationScreenState extends State<MainNavigationScreen> {
                 icon: FontAwesomeIcons.house,
                 selectedIcon: FontAwesomeIcons.house,
                 onTap: () => _onTap(0),
+                selectedIndex: _selectedIndex,
               ),
 
               NavTab(
@@ -68,12 +69,13 @@ class _MainNavigationScreenState extends State<MainNavigationScreen> {
                 icon: FontAwesomeIcons.compass,
                 selectedIcon: FontAwesomeIcons.solidCompass,
                 onTap: () => _onTap(1),
+                selectedIndex: _selectedIndex,
               ),
 
               Gaps.h24,
               GestureDetector(
                 onTap: _onPostVideoButtonTap,
-                child: PostVideoButton(),
+                child: PostVideoButton(inverted: _selectedIndex != 0),
               ),
               Gaps.h24,
 
@@ -83,6 +85,7 @@ class _MainNavigationScreenState extends State<MainNavigationScreen> {
                 icon: FontAwesomeIcons.message,
                 selectedIcon: FontAwesomeIcons.solidMessage,
                 onTap: () => _onTap(3),
+                selectedIndex: _selectedIndex,
               ),
 
               NavTab(
@@ -91,6 +94,7 @@ class _MainNavigationScreenState extends State<MainNavigationScreen> {
                 icon: FontAwesomeIcons.user,
                 selectedIcon: FontAwesomeIcons.solidUser,
                 onTap: () => _onTap(4),
+                selectedIndex: _selectedIndex,
               ),
             ],
           ),

--- a/lib/features/main_navigation/widgets/nav_tab.dart
+++ b/lib/features/main_navigation/widgets/nav_tab.dart
@@ -10,6 +10,7 @@ class NavTab extends StatelessWidget {
     required this.onTap,
     required this.isSelected,
     required this.selectedIcon,
+    required this.selectedIndex,
   });
 
   final String text;
@@ -17,6 +18,7 @@ class NavTab extends StatelessWidget {
   final IconData selectedIcon;
   final Function onTap;
   final bool isSelected;
+  final int selectedIndex;
 
   @override
   Widget build(BuildContext context) {
@@ -24,16 +26,24 @@ class NavTab extends StatelessWidget {
       child: GestureDetector(
         onTap: () => onTap(),
         child: Container(
-          color: Colors.transparent,
+          color: selectedIndex == 0 ? Colors.transparent : Colors.white,
           child: AnimatedOpacity(
             duration: Duration(milliseconds: 300),
             opacity: isSelected ? 1 : 0.6,
             child: Column(
               mainAxisSize: MainAxisSize.min,
               children: [
-                FaIcon(isSelected ? selectedIcon : icon, color: Colors.white),
+                FaIcon(
+                  isSelected ? selectedIcon : icon,
+                  color: selectedIndex == 0 ? Colors.white : Colors.black,
+                ),
                 Gaps.v5,
-                Text(text, style: TextStyle(color: Colors.white)),
+                Text(
+                  text,
+                  style: TextStyle(
+                    color: selectedIndex == 0 ? Colors.white : Colors.black,
+                  ),
+                ),
               ],
             ),
           ),

--- a/lib/features/main_navigation/widgets/post_video_button.dart
+++ b/lib/features/main_navigation/widgets/post_video_button.dart
@@ -3,7 +3,9 @@ import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:tiktong/constants/sizes.dart';
 
 class PostVideoButton extends StatelessWidget {
-  const PostVideoButton({super.key});
+  const PostVideoButton({super.key, required this.inverted});
+
+  final bool inverted;
 
   @override
   Widget build(BuildContext context) {
@@ -40,11 +42,15 @@ class PostVideoButton extends StatelessWidget {
           height: 34,
           padding: EdgeInsets.symmetric(horizontal: Sizes.size12),
           decoration: BoxDecoration(
-            color: Colors.white,
+            color: !inverted ? Colors.white : Colors.black,
             borderRadius: BorderRadius.circular(Sizes.size10),
           ),
-          child: const Center(
-            child: FaIcon(FontAwesomeIcons.plus, color: Colors.black, size: 18),
+          child: Center(
+            child: FaIcon(
+              FontAwesomeIcons.plus,
+              color: !inverted ? Colors.black : Colors.white,
+              size: 18,
+            ),
           ),
         ),
       ],


### PR DESCRIPTION
## 9.1 Light Navigation

### 화면
![Image](https://github.com/user-attachments/assets/45687b5c-2b0d-4534-924f-e72d53fbbbe9)

### 작업 내역
- [x] 홈이 아닌 탭의 경우 Navigation색 반전