### PR TITLE
#9.5 Cupertino Search Text Field

### DIFF
--- a/lib/features/discover/discover_screen.dart
+++ b/lib/features/discover/discover_screen.dart
@@ -56,13 +56,19 @@ class DiscoverScreen extends StatelessWidget {
               itemBuilder:
                   (context, index) => Column(
                     children: [
-                      AspectRatio(
-                        aspectRatio: 9 / 12,
-                        child: FadeInImage.assetNetwork(
-                          fit: BoxFit.cover,
-                          placeholder: "assets/images/placeholder.jpg",
-                          image:
-                              "https://images.unsplash.com/photo-1745503262235-611b59926297?q=80&w=1970&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+                      Container(
+                        clipBehavior: Clip.hardEdge,
+                        decoration: BoxDecoration(
+                          borderRadius: BorderRadius.circular(Sizes.size4),
+                        ),
+                        child: AspectRatio(
+                          aspectRatio: 9 / 12,
+                          child: FadeInImage.assetNetwork(
+                            fit: BoxFit.cover,
+                            placeholder: "assets/images/placeholder.jpg",
+                            image:
+                                "https://images.unsplash.com/photo-1745503262235-611b59926297?q=80&w=1970&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+                          ),
                         ),
                       ),
                       Gaps.v10,

--- a/lib/features/discover/discover_screen.dart
+++ b/lib/features/discover/discover_screen.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:tiktong/constants/gaps.dart';
@@ -5,17 +6,50 @@ import 'package:tiktong/constants/sizes.dart';
 
 final tabs = ["Top", "Users", "Videos", "Sounds", "LIVE", "Shopping", "Brands"];
 
-class DiscoverScreen extends StatelessWidget {
+class DiscoverScreen extends StatefulWidget {
   const DiscoverScreen({super.key});
+
+  @override
+  State<DiscoverScreen> createState() => _DiscoverScreenState();
+}
+
+class _DiscoverScreenState extends State<DiscoverScreen> {
+  final TextEditingController _textEditingController = TextEditingController(
+    text: "Initial Text",
+  );
+
+  void _onSearchChanged(String value) {
+    print(value);
+  }
+
+  void _onSearchSubmitted(String value) {
+    print(value);
+  }
+
+  // 상단 탭바 누르면 포커스 해제
+  void _onTap(int index) {
+    FocusScope.of(context).unfocus();
+  }
+
+  @override
+  void dispose() {
+    _textEditingController.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
     return DefaultTabController(
       length: tabs.length,
       child: Scaffold(
+        resizeToAvoidBottomInset: false,
         appBar: AppBar(
           elevation: 1,
-          title: const Text("Discover"),
+          title: CupertinoSearchTextField(
+            controller: _textEditingController,
+            onChanged: _onSearchChanged,
+            onSubmitted: _onSearchSubmitted,
+          ),
           bottom: TabBar(
             // 클릭 애니메이션 제거
             splashFactory: NoSplash.splashFactory,
@@ -23,6 +57,7 @@ class DiscoverScreen extends StatelessWidget {
             // 탭바 정렬
             tabAlignment: TabAlignment.start,
 
+            onTap: _onTap,
             padding: const EdgeInsets.symmetric(horizontal: Sizes.size16),
             isScrollable: true,
             labelStyle: TextStyle(
@@ -38,6 +73,7 @@ class DiscoverScreen extends StatelessWidget {
         body: TabBarView(
           children: [
             GridView.builder(
+              keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
               padding: const EdgeInsets.all(Sizes.size6),
               itemCount: 20,
               gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -16,6 +16,9 @@ class TikTongApp extends StatelessWidget {
       theme: ThemeData(
         useMaterial3: true,
         scaffoldBackgroundColor: Colors.white,
+        textSelectionTheme: const TextSelectionThemeData(
+          cursorColor: Color(0xFFE9435A),
+        ),
         appBarTheme: AppBarTheme(
           foregroundColor: Colors.black,
           backgroundColor: Colors.white,


### PR DESCRIPTION
## 9.5 Cupertino Search Text Field

### 화면
![Image](https://github.com/user-attachments/assets/4d4460c2-b6f2-4d1d-8a78-e47ffe2cf521)

### 작업 내역
- [x] 검색창에 입력되는 값 print 해보기
- [x] 드래그 시 검색창에 포커스 해제
- [x] 상단 탭바 클릭 시 포커스 해제
- [x] `CupertinoSearchTextField`위젯 추가