### PR TITLE
#11.3 AnimatedList part Two

### DIFF
--- a/lib/features/inbox/chat_detail_screen.dart
+++ b/lib/features/inbox/chat_detail_screen.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+
+class ChatDetailScreen extends StatefulWidget {
+  const ChatDetailScreen({super.key});
+
+  @override
+  State<ChatDetailScreen> createState() => _ChatDetailScreenState();
+}
+
+class _ChatDetailScreenState extends State<ChatDetailScreen> {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(centerTitle: true, title: Text("Chat Detail Screen")),
+    );
+  }
+}

--- a/lib/features/inbox/chats_screen.dart
+++ b/lib/features/inbox/chats_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:tiktong/constants/sizes.dart';
+import 'package:tiktong/features/inbox/chat_detail_screen.dart';
 
 class ChatsScreen extends StatefulWidget {
   const ChatsScreen({super.key});
@@ -14,14 +15,64 @@ class _ChatsScreenState extends State<ChatsScreen> {
 
   final List<int> _items = [];
 
+  final Duration _duration = Duration(milliseconds: 400);
+
   void _addItem() {
     if (_key.currentState != null) {
-      _key.currentState!.insertItem(
-        _items.length,
-        duration: Duration(milliseconds: 400),
-      );
+      _key.currentState!.insertItem(_items.length, duration: _duration);
       _items.add(_items.length);
     }
+  }
+
+  void _deleteItem(int index) {
+    if (_key.currentState != null) {
+      // 두번째 parameter는 View로부터 아이템을 삭제할 때 보여주고싶은 아이템을 반환해야 합니다.
+      _key.currentState!.removeItem(
+        index,
+        (context, animation) => SizeTransition(
+          sizeFactor: animation,
+          child: Container(color: Colors.red, child: _makeTile(index)),
+        ),
+        duration: _duration,
+      );
+      _items.removeAt(index);
+    }
+  }
+
+  void _onChatTap() {
+    Navigator.of(
+      context,
+    ).push(MaterialPageRoute(builder: (context) => const ChatDetailScreen()));
+  }
+
+  Widget _makeTile(int index) {
+    return ListTile(
+      onLongPress: () => _deleteItem(index),
+      onTap: _onChatTap,
+      leading: CircleAvatar(
+        backgroundColor: Colors.deepPurple,
+        radius: 30,
+        foregroundImage: NetworkImage(
+          "https://avatars.githubusercontent.com/u/50567588?v=4",
+        ),
+        child: Text("인수", style: TextStyle(color: Colors.white)),
+      ),
+      title: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        crossAxisAlignment: CrossAxisAlignment.end,
+        children: [
+          Text("Nico ($index)", style: TextStyle(fontWeight: FontWeight.w600)),
+          Text(
+            "2:16 PM",
+            style: TextStyle(
+              fontSize: Sizes.size12,
+              color: Colors.grey.shade500,
+            ),
+          ),
+        ],
+      ),
+      subtitle: Text("Don't forget to make video"),
+    );
   }
 
   @override
@@ -52,34 +103,7 @@ class _ChatsScreenState extends State<ChatsScreen> {
               scale: animation,
               child: SizeTransition(
                 sizeFactor: animation,
-                child: ListTile(
-                  leading: CircleAvatar(
-                    backgroundColor: Colors.deepPurple,
-                    radius: 30,
-                    foregroundImage: NetworkImage(
-                      "https://avatars.githubusercontent.com/u/50567588?v=4",
-                    ),
-                    child: Text("인수", style: TextStyle(color: Colors.white)),
-                  ),
-                  title: Row(
-                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                    crossAxisAlignment: CrossAxisAlignment.end,
-                    children: [
-                      Text(
-                        "Nico ($index)",
-                        style: TextStyle(fontWeight: FontWeight.w600),
-                      ),
-                      Text(
-                        "2:16 PM",
-                        style: TextStyle(
-                          fontSize: Sizes.size12,
-                          color: Colors.grey.shade500,
-                        ),
-                      ),
-                    ],
-                  ),
-                  subtitle: Text("Don't forget to make video"),
-                ),
+                child: _makeTile(index),
               ),
             ),
           );


### PR DESCRIPTION
## 11.3 AnimatedList part Two

### 화면
![Image](https://github.com/user-attachments/assets/43210edc-acf6-474c-8afa-50785cde8fff)

### 작업 내역
- [x] 추가된 DM 리스트를 계~속 누르면 삭제되도록 기능구현
- [x] 리스트 아이템 삭제 시 애니메이션이 동작하도록 구현
- [x] 리스트 아이템 생성/삭제 시 사용하는 위젯 묶음 `_makeTile`이라는 이름으로 분리