### PR TITLE
#12.2 SliverAppBar

### DIFF
--- a/lib/features/users/user_profile_screen.dart
+++ b/lib/features/users/user_profile_screen.dart
@@ -15,8 +15,9 @@ class _UserProfileScreenState extends State<UserProfileScreen> {
       slivers: [
         SliverAppBar(
           floating: true,
-          stretch: true,
           pinned: true,
+          snap: true,
+          stretch: true,
           backgroundColor: Colors.teal,
           collapsedHeight: 80,
           expandedHeight: 200,
@@ -35,7 +36,20 @@ class _UserProfileScreenState extends State<UserProfileScreen> {
           centerTitle: true,
         ),
         SliverFixedExtentList(
-          delegate: SliverChildBuilderDelegate((context, index) => Container()),
+          delegate: SliverChildBuilderDelegate(
+            // 리스트 아이템 개수
+            childCount: 50,
+
+            (context, index) => Container(
+              color: Colors.amber[100 * (index % 9)],
+              child: Align(
+                alignment: Alignment.center,
+                child: Text("Item $index"),
+              ),
+            ),
+          ),
+
+          // 리스트 아이템 높이
           itemExtent: 100,
         ),
       ],


### PR DESCRIPTION
## 12.2 SliverAppBar

### 화면
![Image](https://github.com/user-attachments/assets/98a7c636-f125-48f0-8e24-a319b8f2e64f)

### 작업 내역
- [x] 리스트를 추가하고 `SliverAppBar`위젯의 애니메이션 동작 설정

### 애니메이션 설정
- `floating`을 `true`로 해주면 어느 스크롤 포인트에서라도 화면을 아래로 당겨 스크롤을 올리면 사라졌던 SliverAppBar위젯이 바로 나타납니다.
- `pinned`를 `true`로 해주면 항상 `SliverAppBar`위젯에서 flexibleSpace에 있는 위젯이 남아있습니다.
- `snap`을 `true`로 해주면 아주 약간의 움직임으로도 부분적으로 `SliverAppBar`위젯이 나타나는 게 아니라 전체가 사라지거나 나타나도록할 수 있습니다.
- `strach`를 `true`로 해주면 리스트의 가장 위에서 화면을 아래로 당겼을 때 첫번째 리스트아이템이 늘어나는 것이 아닌 `SliverAppBar`가 늘어나게 됩니다.