### PR TITLE
#12.4 SliverPersistentHeader

### DIFF
--- a/lib/features/users/user_profile_screen.dart
+++ b/lib/features/users/user_profile_screen.dart
@@ -36,6 +36,11 @@ class _UserProfileScreenState extends State<UserProfileScreen> {
           title: Text("Hello!"),
           centerTitle: true,
         ),
+        SliverToBoxAdapter(
+          child: Column(
+            children: [CircleAvatar(backgroundColor: Colors.red, radius: 20)],
+          ),
+        ),
         SliverFixedExtentList(
           delegate: SliverChildBuilderDelegate(
             // 리스트 아이템 개수
@@ -53,6 +58,7 @@ class _UserProfileScreenState extends State<UserProfileScreen> {
           // 리스트 아이템 높이
           itemExtent: 100,
         ),
+        SliverPersistentHeader(pinned: true, delegate: CustomDelegate()),
         SliverGrid(
           delegate: SliverChildBuilderDelegate(
             childCount: 50,
@@ -73,5 +79,36 @@ class _UserProfileScreenState extends State<UserProfileScreen> {
         ),
       ],
     );
+  }
+}
+
+class CustomDelegate extends SliverPersistentHeaderDelegate {
+  @override
+  Widget build(
+    BuildContext context,
+    double shrinkOffset,
+    bool overlapsContent,
+  ) {
+    return Container(
+      color: Colors.indigo,
+      child: FractionallySizedBox(
+        // 부모로부터 차지하는 높이 비율
+        heightFactor: 1,
+        child: Center(
+          child: Text("Title!", style: TextStyle(color: Colors.white)),
+        ),
+      ),
+    );
+  }
+
+  @override
+  double get maxExtent => 150;
+
+  @override
+  double get minExtent => 80;
+
+  @override
+  bool shouldRebuild(covariant SliverPersistentHeaderDelegate oldDelegate) {
+    return false;
   }
 }


### PR DESCRIPTION
## 12.4 SliverPersistentHeader

### 화면
![Image](https://github.com/user-attachments/assets/390d86e3-523e-4f4b-aef8-3dde47c31ef2)

### 작업 내역
- [x] `SliverPersistentHeader` 위젯을 이용해 스크롤 중간부터 추가헤더가 생기도록 구현