### PR TITLE
#13.4 CupertinoAlertDialog

### DIFF
--- a/lib/features/settings/settings_screen.dart
+++ b/lib/features/settings/settings_screen.dart
@@ -1,4 +1,6 @@
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 
 class SettingsScreen extends StatefulWidget {
   const SettingsScreen({super.key});
@@ -128,7 +130,61 @@ class _SettingsScreenState extends State<SettingsScreen> {
             title: Text("What is your birthday?"),
           ),
 
-          AboutListTile(applicationName: "TikTong"),
+          ListTile(
+            title: Text("Log out (iOS)"),
+            textColor: Colors.red,
+            onTap: () {
+              showCupertinoDialog(
+                context: context,
+                builder:
+                    (context) => CupertinoAlertDialog(
+                      title: Text("Are you sure?"),
+                      content: Text("Plz dont go"),
+                      actions: [
+                        CupertinoDialogAction(
+                          onPressed: () => Navigator.of(context).pop(),
+                          child: Text("No"),
+                        ),
+                        CupertinoDialogAction(
+                          onPressed: () => Navigator.of(context).pop(),
+                          child: Text("Yes"),
+                        ),
+                      ],
+                    ),
+              );
+            },
+          ),
+
+          ListTile(
+            title: Text("Log out (Android)"),
+            textColor: Colors.red,
+            onTap: () {
+              showDialog(
+                context: context,
+                builder:
+                    (context) => AlertDialog(
+                      title: Text("Are you sure?"),
+                      content: Text("Plz dont go"),
+                      actions: [
+                        IconButton(
+                          onPressed: () => Navigator.of(context).pop(),
+                          icon: FaIcon(FontAwesomeIcons.car),
+                        ),
+                        TextButton(
+                          onPressed: () => Navigator.of(context).pop(),
+                          child: Text("Yes"),
+                        ),
+                      ],
+                    ),
+              );
+            },
+          ),
+
+          AboutListTile(
+            applicationName: "TikTong",
+            applicationVersion: "1.0",
+            applicationLegalese: "Don't copy me.",
+          ),
         ],
       ),
     );


### PR DESCRIPTION
## 13.4 CupertinoAlertDialog

### 화면
<img width="1346" alt="Image" src="https://github.com/user-attachments/assets/dfe22547-bdbe-4d04-adb1-0d3da94fb3c2" />

### 작업 내역
- [x]  `CupertinoAlertDialog`위젯으로 iOS 에서 사용하는 Alert Dialog 구현
- [x] `AlertDialog`위젯으로 Android 에서 사용하는 Alert Dialog 구현