### PR TITLE
#13.5 CupertinoActionSheet

### DIFF
--- a/lib/features/settings/settings_screen.dart
+++ b/lib/features/settings/settings_screen.dart
@@ -180,6 +180,36 @@ class _SettingsScreenState extends State<SettingsScreen> {
             },
           ),
 
+          ListTile(
+            title: Text("Log out (iOS / Bottom)"),
+            textColor: Colors.red,
+            onTap: () {
+              showCupertinoModalPopup(
+                context: context,
+                builder:
+                    (context) => CupertinoActionSheet(
+                      title: Text("Are you sure?"),
+                      message: Text("Please dont go"),
+                      actions: [
+                        CupertinoActionSheetAction(
+                          isDefaultAction: true,
+                          onPressed: () => Navigator.of(context).pop(),
+                          child: Text(
+                            "Not log out",
+                            style: TextStyle(color: Colors.blue),
+                          ),
+                        ),
+                        CupertinoActionSheetAction(
+                          isDestructiveAction: true,
+                          onPressed: () => Navigator.of(context).pop(),
+                          child: Text("Yes plz."),
+                        ),
+                      ],
+                    ),
+              );
+            },
+          ),
+
           AboutListTile(
             applicationName: "TikTong",
             applicationVersion: "1.0",


### PR DESCRIPTION
## 13.5 CupertinoActionSheet

### 화면
<img width="1349" alt="Image" src="https://github.com/user-attachments/assets/a8575d89-5e17-4fde-8555-66b017e00005" />

### 작업 내역
- [x] `CupertinoActionSheet`위젯을 사용해서 모달 외부 Overlay 클릭 시 모달이 닫히도록 기능 구현