### PR TITLE
#14.3 MediaQuery

### DIFF
--- a/lib/features/discover/discover_screen.dart
+++ b/lib/features/discover/discover_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
+import 'package:tiktong/constants/breakpoints.dart';
 import 'package:tiktong/constants/gaps.dart';
 import 'package:tiktong/constants/sizes.dart';
 
@@ -37,6 +38,9 @@ class _DiscoverScreenState extends State<DiscoverScreen> {
 
   @override
   Widget build(BuildContext context) {
+    // 화면 너비
+    final width = MediaQuery.of(context).size.width;
+
     return DefaultTabController(
       length: tabs.length,
       child: Scaffold(
@@ -76,7 +80,7 @@ class _DiscoverScreenState extends State<DiscoverScreen> {
               itemCount: 20,
               gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
                 // Column 개수
-                crossAxisCount: 2,
+                crossAxisCount: width > Breakpoints.lg ? 5 : 2,
 
                 // Grid 좌우 간격
                 crossAxisSpacing: Sizes.size10,


### PR DESCRIPTION
## 14.3 MediaQuery

### 화면
<img width="1729" alt="Image" src="https://github.com/user-attachments/assets/19abc385-8bb4-462c-9d31-82c286feda32" />

### 작업 내역
- [x] 화면 너비에 따라 Discover 탭의 Grid Column 개수 변경되도록 `MediaQuery`위젯을 이용해서 구현