### PR TITLE
#14.5 ConstrainedBox

### DIFF
--- a/lib/constants/breakpoints.dart
+++ b/lib/constants/breakpoints.dart
@@ -1,7 +1,7 @@
 class Breakpoints {
-  static const sm = 640;
-  static const md = 768;
-  static const lg = 1024;
-  static const xl = 1280;
-  static const xxl = 1536;
+  static const sm = 640.0;
+  static const md = 768.0;
+  static const lg = 1024.0;
+  static const xl = 1280.0;
+  static const xxl = 1536.0;
 }

--- a/lib/features/discover/discover_screen.dart
+++ b/lib/features/discover/discover_screen.dart
@@ -47,10 +47,13 @@ class _DiscoverScreenState extends State<DiscoverScreen> {
         resizeToAvoidBottomInset: false,
         appBar: AppBar(
           elevation: 1,
-          title: CupertinoSearchTextField(
-            controller: _textEditingController,
-            onChanged: _onSearchChanged,
-            onSubmitted: _onSearchSubmitted,
+          title: ConstrainedBox(
+            constraints: BoxConstraints(maxWidth: Breakpoints.sm),
+            child: CupertinoSearchTextField(
+              controller: _textEditingController,
+              onChanged: _onSearchChanged,
+              onSubmitted: _onSearchSubmitted,
+            ),
           ),
           bottom: TabBar(
             // 클릭 애니메이션 제거


### PR DESCRIPTION
## 14.5 ConstrainedBox

### 화면
<img width="1663" alt="Image" src="https://github.com/user-attachments/assets/d19b6f91-9e21-4dc3-81c9-69926194e7bd" />

### 작업 내역
- [x] 상단 검색 바 크기가 일정 너비이상 커지지 않게 `ConstrainedBox`위젯으로 제한