### PR TITLE
#15.4 버전 차이로 인한 primary 색상 적용방식 변경

### DIFF
--- a/lib/features/authentication/login_screen.dart
+++ b/lib/features/authentication/login_screen.dart
@@ -30,9 +30,10 @@ class LoginScreen extends StatelessWidget {
               Gaps.v80,
               Text(
                 "Log in for TikTong",
-                style: Theme.of(
-                  context,
-                ).textTheme.headlineMedium!.copyWith(color: Colors.blue),
+                style: TextStyle(
+                  fontSize: Sizes.size24,
+                  fontWeight: FontWeight.w700,
+                ),
               ),
               Gaps.v20,
               Opacity(

--- a/lib/features/authentication/sign_up_screen.dart
+++ b/lib/features/authentication/sign_up_screen.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:google_fonts/google_fonts.dart';
 import 'package:tiktong/constants/gaps.dart';
 import 'package:tiktong/constants/sizes.dart';
 import 'package:tiktong/features/authentication/username_screen.dart';
@@ -40,8 +39,9 @@ class SignUpScreen extends StatelessWidget {
                   Gaps.v80,
                   Text(
                     "Sign up for TikTong",
-                    style: GoogleFonts.abrilFatface(
-                      textStyle: Theme.of(context).textTheme.headlineMedium,
+                    style: TextStyle(
+                      fontSize: Sizes.size24,
+                      fontWeight: FontWeight.w700,
                     ),
                   ),
                   Gaps.v20,
@@ -49,7 +49,7 @@ class SignUpScreen extends StatelessWidget {
                     opacity: 0.7,
                     child: Text(
                       "Create a profile, follow other accounts, make your own videos, and more.",
-                      style: Theme.of(context).textTheme.titleMedium,
+                      style: TextStyle(fontSize: Sizes.size16),
                       textAlign: TextAlign.center,
                     ),
                   ),

--- a/lib/features/authentication/widgets/form_button.dart
+++ b/lib/features/authentication/widgets/form_button.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:tiktong/constants/sizes.dart';
+import 'package:tiktong/utils.dart';
 
 class FormButton extends StatelessWidget {
   const FormButton({super.key, required this.disabled, this.title = "Next"});
@@ -16,7 +17,12 @@ class FormButton extends StatelessWidget {
         padding: const EdgeInsets.symmetric(vertical: Sizes.size16),
         decoration: BoxDecoration(
           borderRadius: BorderRadius.circular(Sizes.size5),
-          color: disabled ? Colors.grey[300] : Theme.of(context).primaryColor,
+          color:
+              disabled
+                  ? isDarkMode(context)
+                      ? Colors.grey.shade800
+                      : Colors.grey.shade300
+                  : Theme.of(context).colorScheme.primary,
         ),
         child: AnimatedDefaultTextStyle(
           duration: const Duration(milliseconds: 500),

--- a/lib/features/inbox/chat_detail_screen.dart
+++ b/lib/features/inbox/chat_detail_screen.dart
@@ -82,7 +82,9 @@ class _ChatDetailScreenState extends State<ChatDetailScreen> {
                     padding: const EdgeInsets.all(Sizes.size14),
                     decoration: BoxDecoration(
                       color:
-                          isMine ? Colors.blue : Theme.of(context).primaryColor,
+                          isMine
+                              ? Colors.blue
+                              : Theme.of(context).colorScheme.primary,
                       borderRadius: BorderRadius.only(
                         topLeft: Radius.circular(Sizes.size20),
                         topRight: Radius.circular(Sizes.size20),

--- a/lib/features/main_navigation/widgets/post_video_button.dart
+++ b/lib/features/main_navigation/widgets/post_video_button.dart
@@ -32,7 +32,7 @@ class PostVideoButton extends StatelessWidget {
             width: 26,
             padding: EdgeInsets.symmetric(horizontal: Sizes.size8),
             decoration: BoxDecoration(
-              color: Theme.of(context).primaryColor,
+              color: Theme.of(context).colorScheme.primary,
               borderRadius: BorderRadius.circular(Sizes.size10),
             ),
           ),

--- a/lib/features/onboarding/interests_screen.dart
+++ b/lib/features/onboarding/interests_screen.dart
@@ -119,7 +119,9 @@ class _InterestsScreenState extends State<InterestsScreen> {
           child: GestureDetector(
             onTap: _onNextTap,
             child: Container(
-              decoration: BoxDecoration(color: Theme.of(context).primaryColor),
+              decoration: BoxDecoration(
+                color: Theme.of(context).colorScheme.primary,
+              ),
               alignment: Alignment.center,
               child: const Text(
                 "Next",

--- a/lib/features/onboarding/tutorial_screen.dart
+++ b/lib/features/onboarding/tutorial_screen.dart
@@ -118,7 +118,7 @@ class _TutorialScreenState extends State<TutorialScreen> {
               opacity: _showingPage == Page.first ? 0 : 1,
               child: CupertinoButton(
                 onPressed: _onEnterAppTap,
-                color: Theme.of(context).primaryColor,
+                color: Theme.of(context).colorScheme.primary,
                 child: const Text(
                   "Enter the app!",
                   style: TextStyle(color: Colors.white),

--- a/lib/features/onboarding/widgets/interests_button.dart
+++ b/lib/features/onboarding/widgets/interests_button.dart
@@ -30,7 +30,10 @@ class _InterestsButtonState extends State<InterestsButton> {
           horizontal: Sizes.size24,
         ),
         decoration: BoxDecoration(
-          color: _isSelected ? Theme.of(context).primaryColor : Colors.white,
+          color:
+              _isSelected
+                  ? Theme.of(context).colorScheme.primary
+                  : Colors.white,
           borderRadius: BorderRadius.circular(Sizes.size32),
           border: Border.all(color: Colors.black.withValues(alpha: 0.1)),
           boxShadow: [

--- a/lib/features/users/user_profile_screen.dart
+++ b/lib/features/users/user_profile_screen.dart
@@ -106,7 +106,7 @@ class _UserProfileScreenState extends State<UserProfileScreen> {
                                 vertical: Sizes.size12,
                               ),
                               decoration: BoxDecoration(
-                                color: Theme.of(context).primaryColor,
+                                color: Theme.of(context).colorScheme.primary,
                                 borderRadius: BorderRadius.all(
                                   Radius.circular(Sizes.size4),
                                 ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:google_fonts/google_fonts.dart';
 import 'package:tiktong/constants/sizes.dart';
 import 'package:tiktong/features/authentication/sign_up_screen.dart';
 
@@ -26,7 +25,7 @@ class TikTongApp extends StatelessWidget {
       themeMode: ThemeMode.system,
       theme: ThemeData(
         useMaterial3: true,
-        textTheme: GoogleFonts.itimTextTheme(),
+        textTheme: Typography.blackMountainView,
         scaffoldBackgroundColor: Colors.white,
         textSelectionTheme: const TextSelectionThemeData(
           cursorColor: Color(0xFFE9435A),
@@ -48,21 +47,22 @@ class TikTongApp extends StatelessWidget {
           color: Colors.white,
         ),
         colorScheme: ColorScheme.fromSeed(
-          seedColor: Color(0xFFE9435A),
+          primary: Color(0xFFE9435A),
+          seedColor: Colors.white,
           brightness: Brightness.light,
         ).copyWith(primary: Color(0xFFE9435A)),
       ),
 
       darkTheme: ThemeData(
         useMaterial3: true,
-        textTheme: GoogleFonts.itimTextTheme(
-          ThemeData(brightness: Brightness.dark).textTheme,
-        ),
+        textTheme: Typography.whiteMountainView,
         scaffoldBackgroundColor: Colors.black,
+        appBarTheme: AppBarTheme(backgroundColor: Colors.grey.shade900),
         colorScheme: ColorScheme.fromSeed(
+          primary: Color(0xFFE9435A),
           brightness: Brightness.dark,
-          seedColor: Color(0xFFE9435A),
-        ).copyWith(primary: Color(0xFFE9435A)),
+          seedColor: Colors.black,
+        ),
         bottomAppBarTheme: BottomAppBarTheme(
           surfaceTintColor: Colors.black,
           color: Colors.grey.shade900,


### PR DESCRIPTION
## 15.4 Typography

### 화면
<img width="1276" alt="Image" src="https://github.com/user-attachments/assets/d4ff867d-f15d-4319-b55e-a66f33883b71" />

### 작업내역
- [x] 버전 변경에 따른 primary 테마 적용 변경 방식 수정
- [x] textTheme의 `Typography`적용해서 폰트 크기 등을 적용하지 않고 폰트 패밀리만 적용하도록 수정