### PR TITLE
#15.6 Dark Mode part Two

### DIFF
--- a/lib/features/inbox/activity_screen.dart
+++ b/lib/features/inbox/activity_screen.dart
@@ -136,24 +136,17 @@ class _ActivityScreenState extends State<ActivityScreen>
                       width: Sizes.size52,
                       decoration: BoxDecoration(
                         shape: BoxShape.circle,
-                        color: Colors.white,
                         border: Border.all(
                           color: Colors.grey.shade400,
                           width: Sizes.size1,
                         ),
                       ),
-                      child: const Center(
-                        child: FaIcon(
-                          FontAwesomeIcons.bell,
-                          color: Colors.black,
-                        ),
-                      ),
+                      child: const Center(child: FaIcon(FontAwesomeIcons.bell)),
                     ),
                     title: RichText(
                       text: TextSpan(
                         text: "Account updates:",
                         style: TextStyle(
-                          color: Colors.black,
                           fontSize: Sizes.size16,
                           fontWeight: FontWeight.w600,
                         ),
@@ -190,7 +183,7 @@ class _ActivityScreenState extends State<ActivityScreen>
             position: _panelAnimation,
             child: Container(
               decoration: BoxDecoration(
-                color: Colors.white,
+                color: Theme.of(context).appBarTheme.backgroundColor,
                 borderRadius: BorderRadius.only(
                   bottomLeft: Radius.circular(Sizes.size4),
                   bottomRight: Radius.circular(Sizes.size4),
@@ -203,11 +196,7 @@ class _ActivityScreenState extends State<ActivityScreen>
                     ListTile(
                       title: Row(
                         children: [
-                          FaIcon(
-                            tab["icon"],
-                            color: Colors.black,
-                            size: Sizes.size16,
-                          ),
+                          Icon(tab["icon"], size: Sizes.size16),
                           Gaps.h20,
                           Text(
                             tab["title"],

--- a/lib/features/inbox/inbox_screen.dart
+++ b/lib/features/inbox/inbox_screen.dart
@@ -49,11 +49,7 @@ class _InBoxScreenState extends State<InBoxScreen> {
                 fontWeight: FontWeight.w600,
               ),
             ),
-            trailing: FaIcon(
-              FontAwesomeIcons.chevronRight,
-              size: Sizes.size14,
-              color: Colors.black,
-            ),
+            trailing: FaIcon(FontAwesomeIcons.chevronRight, size: Sizes.size14),
           ),
           Container(height: Sizes.size1, color: Colors.grey.shade300),
           ListTile(

--- a/lib/features/videos/widgets/video_comments.dart
+++ b/lib/features/videos/widgets/video_comments.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:tiktong/constants/gaps.dart';
 import 'package:tiktong/constants/sizes.dart';
+import 'package:tiktong/utils.dart';
 
 class VideoComments extends StatefulWidget {
   const VideoComments({super.key});
@@ -35,6 +36,7 @@ class _VideoCommentsState extends State<VideoComments> {
   @override
   Widget build(BuildContext context) {
     final size = MediaQuery.of(context).size;
+    final isDark = isDarkMode(context);
 
     return Container(
       height: size.height * 0.7,
@@ -43,9 +45,9 @@ class _VideoCommentsState extends State<VideoComments> {
         borderRadius: BorderRadius.circular(Sizes.size14),
       ),
       child: Scaffold(
-        backgroundColor: Colors.grey.shade50,
+        backgroundColor: isDark ? null : Colors.grey.shade50,
         appBar: AppBar(
-          backgroundColor: Colors.grey.shade50,
+          backgroundColor: isDark ? null : Colors.grey.shade50,
           automaticallyImplyLeading: false,
           title: const Text("22796 comments"),
           actions: [
@@ -124,7 +126,6 @@ class _VideoCommentsState extends State<VideoComments> {
                 bottom: 0,
                 width: size.width,
                 child: BottomAppBar(
-                  color: Colors.white,
                   child: Row(
                     children: [
                       CircleAvatar(
@@ -152,7 +153,10 @@ class _VideoCommentsState extends State<VideoComments> {
                                 borderSide: BorderSide.none,
                               ),
                               filled: true,
-                              fillColor: Colors.grey.shade200,
+                              fillColor:
+                                  isDark
+                                      ? Colors.grey.shade800
+                                      : Colors.grey.shade200,
                               contentPadding: EdgeInsets.symmetric(
                                 horizontal: Sizes.size10,
                               ),
@@ -163,17 +167,26 @@ class _VideoCommentsState extends State<VideoComments> {
                                   children: [
                                     FaIcon(
                                       FontAwesomeIcons.at,
-                                      color: Colors.grey.shade900,
+                                      color:
+                                          isDark
+                                              ? Colors.grey.shade500
+                                              : Colors.grey.shade900,
                                     ),
                                     Gaps.h14,
                                     FaIcon(
                                       FontAwesomeIcons.gift,
-                                      color: Colors.grey.shade900,
+                                      color:
+                                          isDark
+                                              ? Colors.grey.shade500
+                                              : Colors.grey.shade900,
                                     ),
                                     Gaps.h14,
                                     FaIcon(
                                       FontAwesomeIcons.faceSmile,
-                                      color: Colors.grey.shade900,
+                                      color:
+                                          isDark
+                                              ? Colors.grey.shade500
+                                              : Colors.grey.shade900,
                                     ),
                                     Gaps.h14,
                                     if (_isWriting)
@@ -181,7 +194,10 @@ class _VideoCommentsState extends State<VideoComments> {
                                         onTap: _stopWriting,
                                         child: FaIcon(
                                           FontAwesomeIcons.circleArrowUp,
-                                          color: Theme.of(context).primaryColor,
+                                          color:
+                                              Theme.of(
+                                                context,
+                                              ).colorScheme.primary,
                                         ),
                                       ),
                                   ],

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -57,6 +57,7 @@ class TikTongApp extends StatelessWidget {
           unselectedLabelColor: Colors.grey.shade500,
           indicatorColor: Colors.black,
         ),
+        listTileTheme: ListTileThemeData(iconColor: Colors.black),
       ),
 
       darkTheme: ThemeData(


### PR DESCRIPTION
## 15.6 Dark Mode part Two

### 화면
<img width="1276" alt="Image" src="https://github.com/user-attachments/assets/73ce8aa5-d4f5-4497-ab6f-b9e2178e9b60" />
<img width="1275" alt="Image" src="https://github.com/user-attachments/assets/2ab40498-3e32-453b-bf15-4538a575f165" />

### 작업 내역
- [x] Inbox탭의 Activity에 다크모드 디자인 추가
- [x] Home탭의 댓글 화면에 다크모드 디자인 추가