### PR TITLE
#16.1 Localization

### DIFF
--- a/lib/features/settings/settings_screen.dart
+++ b/lib/features/settings/settings_screen.dart
@@ -103,119 +103,123 @@ class _SettingsScreenState extends State<SettingsScreen> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(centerTitle: true, title: Text("Settings")),
-      body: ListView(
-        children: [
-          SwitchListTile.adaptive(
-            value: _notifications,
-            onChanged: _onNotificationsChanged,
-            title: Text("Enable notifications"),
-            subtitle: Text("Enable notifications"),
-          ),
+    return Localizations.override(
+      context: context,
+      locale: Locale("ko"),
+      child: Scaffold(
+        appBar: AppBar(centerTitle: true, title: Text("Settings")),
+        body: ListView(
+          children: [
+            SwitchListTile.adaptive(
+              value: _notifications,
+              onChanged: _onNotificationsChanged,
+              title: Text("Enable notifications"),
+              subtitle: Text("Enable notifications"),
+            ),
 
-          CheckboxListTile(
-            activeColor: Colors.black,
-            value: _notifications,
-            onChanged: _onNotificationsChanged,
-            title: Text("Enable notifications"),
-          ),
+            CheckboxListTile(
+              activeColor: Colors.black,
+              value: _notifications,
+              onChanged: _onNotificationsChanged,
+              title: Text("Enable notifications"),
+            ),
 
-          ListTile(
-            onTap: () async {
-              await _showDatePicker();
-              await _showTimePicker();
-              await _showDateRangePicker();
-            },
-            title: Text("What is your birthday?"),
-          ),
+            ListTile(
+              onTap: () async {
+                await _showDatePicker();
+                await _showTimePicker();
+                await _showDateRangePicker();
+              },
+              title: Text("What is your birthday?"),
+            ),
 
-          ListTile(
-            title: Text("Log out (iOS)"),
-            textColor: Colors.red,
-            onTap: () {
-              showCupertinoDialog(
-                context: context,
-                builder:
-                    (context) => CupertinoAlertDialog(
-                      title: Text("Are you sure?"),
-                      content: Text("Plz dont go"),
-                      actions: [
-                        CupertinoDialogAction(
-                          onPressed: () => Navigator.of(context).pop(),
-                          child: Text("No"),
-                        ),
-                        CupertinoDialogAction(
-                          onPressed: () => Navigator.of(context).pop(),
-                          child: Text("Yes"),
-                        ),
-                      ],
-                    ),
-              );
-            },
-          ),
-
-          ListTile(
-            title: Text("Log out (Android)"),
-            textColor: Colors.red,
-            onTap: () {
-              showDialog(
-                context: context,
-                builder:
-                    (context) => AlertDialog(
-                      title: Text("Are you sure?"),
-                      content: Text("Plz dont go"),
-                      actions: [
-                        IconButton(
-                          onPressed: () => Navigator.of(context).pop(),
-                          icon: FaIcon(FontAwesomeIcons.car),
-                        ),
-                        TextButton(
-                          onPressed: () => Navigator.of(context).pop(),
-                          child: Text("Yes"),
-                        ),
-                      ],
-                    ),
-              );
-            },
-          ),
-
-          ListTile(
-            title: Text("Log out (iOS / Bottom)"),
-            textColor: Colors.red,
-            onTap: () {
-              showCupertinoModalPopup(
-                context: context,
-                builder:
-                    (context) => CupertinoActionSheet(
-                      title: Text("Are you sure?"),
-                      message: Text("Please dont go"),
-                      actions: [
-                        CupertinoActionSheetAction(
-                          isDefaultAction: true,
-                          onPressed: () => Navigator.of(context).pop(),
-                          child: Text(
-                            "Not log out",
-                            style: TextStyle(color: Colors.blue),
+            ListTile(
+              title: Text("Log out (iOS)"),
+              textColor: Colors.red,
+              onTap: () {
+                showCupertinoDialog(
+                  context: context,
+                  builder:
+                      (context) => CupertinoAlertDialog(
+                        title: Text("Are you sure?"),
+                        content: Text("Plz dont go"),
+                        actions: [
+                          CupertinoDialogAction(
+                            onPressed: () => Navigator.of(context).pop(),
+                            child: Text("No"),
                           ),
-                        ),
-                        CupertinoActionSheetAction(
-                          isDestructiveAction: true,
-                          onPressed: () => Navigator.of(context).pop(),
-                          child: Text("Yes plz."),
-                        ),
-                      ],
-                    ),
-              );
-            },
-          ),
+                          CupertinoDialogAction(
+                            onPressed: () => Navigator.of(context).pop(),
+                            child: Text("Yes"),
+                          ),
+                        ],
+                      ),
+                );
+              },
+            ),
 
-          AboutListTile(
-            applicationName: "TikTong",
-            applicationVersion: "1.0",
-            applicationLegalese: "Don't copy me.",
-          ),
-        ],
+            ListTile(
+              title: Text("Log out (Android)"),
+              textColor: Colors.red,
+              onTap: () {
+                showDialog(
+                  context: context,
+                  builder:
+                      (context) => AlertDialog(
+                        title: Text("Are you sure?"),
+                        content: Text("Plz dont go"),
+                        actions: [
+                          IconButton(
+                            onPressed: () => Navigator.of(context).pop(),
+                            icon: FaIcon(FontAwesomeIcons.car),
+                          ),
+                          TextButton(
+                            onPressed: () => Navigator.of(context).pop(),
+                            child: Text("Yes"),
+                          ),
+                        ],
+                      ),
+                );
+              },
+            ),
+
+            ListTile(
+              title: Text("Log out (iOS / Bottom)"),
+              textColor: Colors.red,
+              onTap: () {
+                showCupertinoModalPopup(
+                  context: context,
+                  builder:
+                      (context) => CupertinoActionSheet(
+                        title: Text("Are you sure?"),
+                        message: Text("Please dont go"),
+                        actions: [
+                          CupertinoActionSheetAction(
+                            isDefaultAction: true,
+                            onPressed: () => Navigator.of(context).pop(),
+                            child: Text(
+                              "Not log out",
+                              style: TextStyle(color: Colors.blue),
+                            ),
+                          ),
+                          CupertinoActionSheetAction(
+                            isDestructiveAction: true,
+                            onPressed: () => Navigator.of(context).pop(),
+                            child: Text("Yes plz."),
+                          ),
+                        ],
+                      ),
+                );
+              },
+            ),
+
+            AboutListTile(
+              applicationName: "TikTong",
+              applicationVersion: "1.0",
+              applicationLegalese: "Don't copy me.",
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:tiktong/constants/sizes.dart';
 import 'package:tiktong/features/authentication/sign_up_screen.dart';
 import 'package:tiktong/utils.dart';
@@ -22,7 +23,17 @@ class TikTongApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp(
       debugShowCheckedModeBanner: false,
-      title: 'Flutter Demo',
+      title: 'TikTong',
+      localizationsDelegates: [
+        GlobalMaterialLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+      ],
+      supportedLocales: [
+        Locale('en', "US"),
+        Locale('ko', "KR"),
+        Locale("es", "ES"),
+      ],
       themeMode: ThemeMode.system,
       theme: ThemeData(
         useMaterial3: true,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -94,6 +94,11 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.0.0"
+  flutter_localizations:
+    dependency: "direct main"
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -144,6 +149,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.1.2"
+  intl:
+    dependency: "direct main"
+    description:
+      name: intl
+      sha256: d6f56758b7d3014a48af9701c085700aac781a92a87a62b1333b46d8879661cf
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.19.0"
   leak_tracker:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,6 +31,11 @@ dependencies:
   flutter:
     sdk: flutter
 
+  flutter_localizations:
+    sdk: flutter
+
+  intl: any
+
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8


### PR DESCRIPTION
## 16.1 Localization

### 화면
![Image](https://github.com/user-attachments/assets/8b01d4c0-4885-46f1-9237-a528f536cea2)

### 작업 내역
- [x] Localization 설정으로 setting 화면에 Flutter에서 제공해주는 위젯 번역적용
- [x] `main.dark`파일에 영어, 스페인어, 한국어 번역 가능하도록 설정