### PR TITLE
#16.2 l10n

### DIFF
--- a/l10n.yaml
+++ b/l10n.yaml
@@ -1,0 +1,3 @@
+arb-dir: lib/intl
+template-arb-file: intl_en.arb
+output-localization-file: intl_generated.dart

--- a/lib/features/settings/settings_screen.dart
+++ b/lib/features/settings/settings_screen.dart
@@ -19,6 +19,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
         initialDate: DateTime.now(),
         firstDate: DateTime(1980),
         lastDate: DateTime(2030),
+        locale: const Locale('ko', 'KR'),
       );
       if (date != null && mounted) {
         ScaffoldMessenger.of(
@@ -60,6 +61,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
         context: context,
         firstDate: DateTime(1980),
         lastDate: DateTime(2030),
+        locale: const Locale('ko', 'KR'),
         builder: (context, child) {
           return Theme(
             data: Theme.of(context).copyWith(
@@ -105,7 +107,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
   Widget build(BuildContext context) {
     return Localizations.override(
       context: context,
-      locale: Locale("ko"),
+      locale: const Locale('ko', 'KR'),
       child: Scaffold(
         appBar: AppBar(centerTitle: true, title: Text("Settings")),
         body: ListView(

--- a/lib/intl/intl_en.arb
+++ b/lib/intl/intl_en.arb
@@ -1,0 +1,3 @@
+{
+  "signUpTitle": "Sign up for TikTong"
+}

--- a/lib/intl/intl_ko.arb
+++ b/lib/intl/intl_ko.arb
@@ -1,0 +1,3 @@
+{
+  "signUpTitle": "TikTong에 가입하세요"
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4,6 +4,7 @@ import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:tiktong/constants/sizes.dart';
 import 'package:tiktong/features/authentication/sign_up_screen.dart';
 import 'package:tiktong/utils.dart';
+import 'package:flutter_gen/gen_l10n/intl_generated.dart';
 
 void main() async {
   // 화면 Portrait로 고정
@@ -26,6 +27,7 @@ class TikTongApp extends StatelessWidget {
       title: 'TikTong',
       locale: WidgetsBinding.instance.platformDispatcher.locale,
       localizationsDelegates: [
+        AppLocalizations.delegate,
         GlobalMaterialLocalizations.delegate,
         GlobalWidgetsLocalizations.delegate,
         GlobalCupertinoLocalizations.delegate,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -24,12 +24,13 @@ class TikTongApp extends StatelessWidget {
     return MaterialApp(
       debugShowCheckedModeBanner: false,
       title: 'TikTong',
+      locale: WidgetsBinding.instance.platformDispatcher.locale,
       localizationsDelegates: [
         GlobalMaterialLocalizations.delegate,
-        GlobalCupertinoLocalizations.delegate,
         GlobalWidgetsLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
       ],
-      supportedLocales: [
+      supportedLocales: const [
         Locale('en', "US"),
         Locale('ko', "KR"),
         Locale("es", "ES"),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -60,6 +60,7 @@ dev_dependencies:
 
 # The following section is specific to Flutter packages.
 flutter:
+  generate: true
   # The following line ensures that the Material Icons font is
   # included with your application, so that you can use the icons in
   # the material Icons class.


### PR DESCRIPTION
## 16.2 l10n

### 화면
![Image](https://github.com/user-attachments/assets/6ab95aa8-f632-498c-8d88-5cdbcf5854f3)

### 작업 내역
- [x] settings 화면 날짜 기본 위젯 번역 설정
- [x] 번역을 제공하기 위한 `l10n.yaml`파일 추가
- [x] 번역을 위한 `pubspec.yaml` 수정
- [x] 번역을 하고 싶은 기본언어에 문구를 적어놓은 `intl_en.arb` 파일 생성
- [x] 어떻게 번역되는지 작성해놓는 `intl_ko.arb`파일 생성
- [x] `main.dart`에서 flutter 명령어를 통해 자동 생성된 번역 관련 `intl_generated.dart`파일 import

### `.dart`확장자를 가진 번역 파일 생성 명령어
- `arb`파일 작성 후 `l10n.yaml`파일을 작성한 뒤 명령어를 실행합니다.
```bash
flutter gen-l10n
```