### PR TITLE
#17.3 pushNamed

### DIFF
--- a/lib/features/authentication/login_screen.dart
+++ b/lib/features/authentication/login_screen.dart
@@ -7,6 +7,7 @@ import 'package:tiktong/features/authentication/widgets/auth_button.dart';
 import 'package:tiktong/utils.dart';
 
 class LoginScreen extends StatelessWidget {
+  static String routeName = "/login";
   const LoginScreen({super.key});
 
   void onSignUpTap(BuildContext context) {

--- a/lib/features/authentication/sign_up_screen.dart
+++ b/lib/features/authentication/sign_up_screen.dart
@@ -1,24 +1,26 @@
 import 'package:flutter/material.dart';
 import 'package:tiktong/constants/gaps.dart';
 import 'package:tiktong/constants/sizes.dart';
+import 'package:tiktong/features/authentication/login_screen.dart';
 import 'package:tiktong/features/authentication/username_screen.dart';
 import 'package:tiktong/features/authentication/widgets/auth_button.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
-import 'package:tiktong/features/authentication/login_screen.dart';
 import 'package:tiktong/generated/l10n.dart';
 import 'package:tiktong/utils.dart';
 
 class SignUpScreen extends StatelessWidget {
+  static String routeName = "/";
   const SignUpScreen({super.key});
 
   void _onLoginTap(BuildContext context) async {
-    await Navigator.of(
-      context,
-    ).push(MaterialPageRoute(builder: (context) => LoginScreen()));
+    final result = await Navigator.of(context).pushNamed(LoginScreen.routeName);
+    print(result);
   }
 
   void _onEmailTap(BuildContext context) {
-    Navigator.of(context).push(
+    Navigator.of(context).pushNamed(UsernameScreen.routeName);
+
+    /*     Navigator.of(context).push(
       PageRouteBuilder(
         transitionDuration: Duration(milliseconds: 500),
         reverseTransitionDuration: Duration(milliseconds: 500),
@@ -42,7 +44,7 @@ class SignUpScreen extends StatelessWidget {
         pageBuilder:
             (context, animation, secondaryAnimation) => const UsernameScreen(),
       ),
-    );
+    ); */
   }
 
   @override

--- a/lib/features/authentication/username_screen.dart
+++ b/lib/features/authentication/username_screen.dart
@@ -5,6 +5,7 @@ import 'package:tiktong/features/authentication/email_screen.dart';
 import 'package:tiktong/features/authentication/widgets/form_button.dart';
 
 class UsernameScreen extends StatefulWidget {
+  static String routeName = "/username";
   const UsernameScreen({super.key});
 
   @override

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,7 +2,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:tiktong/constants/sizes.dart';
+import 'package:tiktong/features/authentication/login_screen.dart';
 import 'package:tiktong/features/authentication/sign_up_screen.dart';
+import 'package:tiktong/features/authentication/username_screen.dart';
 import 'package:tiktong/generated/l10n.dart';
 import 'package:tiktong/utils.dart';
 
@@ -91,8 +93,13 @@ class TikTongApp extends StatelessWidget {
           indicatorColor: Colors.white,
         ),
       ),
-
-      home: SignUpScreen(),
+      // 라우트 설정
+      initialRoute: SignUpScreen.routeName,
+      routes: {
+        SignUpScreen.routeName: (context) => const SignUpScreen(),
+        UsernameScreen.routeName: (context) => const UsernameScreen(),
+        LoginScreen.routeName: (context) => const LoginScreen(),
+      },
     );
   }
 }


### PR DESCRIPTION
## 17.3 pushNamed

### 화면
![Image](https://github.com/user-attachments/assets/8925501d-6bd8-4e16-890c-c480124fb45b)

### 작업 내역
- [x] 기존 화면전환 방식을 `main.dart`에 routes로 모아서 처리하도록 변경