### PR TITLE
#20.1 _noCamera

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,28 +1,52 @@
 PODS:
+  - camera_avfoundation (0.0.1):
+    - Flutter
   - Flutter (1.0.0)
+  - image_gallery_saver_plus (0.0.1):
+    - Flutter
+  - image_picker_ios (0.0.1):
+    - Flutter
   - path_provider_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
+  - permission_handler_apple (9.3.0):
+    - Flutter
   - video_player_avfoundation (0.0.1):
     - Flutter
     - FlutterMacOS
 
 DEPENDENCIES:
+  - camera_avfoundation (from `.symlinks/plugins/camera_avfoundation/ios`)
   - Flutter (from `Flutter`)
+  - image_gallery_saver_plus (from `.symlinks/plugins/image_gallery_saver_plus/ios`)
+  - image_picker_ios (from `.symlinks/plugins/image_picker_ios/ios`)
   - path_provider_foundation (from `.symlinks/plugins/path_provider_foundation/darwin`)
+  - permission_handler_apple (from `.symlinks/plugins/permission_handler_apple/ios`)
   - video_player_avfoundation (from `.symlinks/plugins/video_player_avfoundation/darwin`)
 
 EXTERNAL SOURCES:
+  camera_avfoundation:
+    :path: ".symlinks/plugins/camera_avfoundation/ios"
   Flutter:
     :path: Flutter
+  image_gallery_saver_plus:
+    :path: ".symlinks/plugins/image_gallery_saver_plus/ios"
+  image_picker_ios:
+    :path: ".symlinks/plugins/image_picker_ios/ios"
   path_provider_foundation:
     :path: ".symlinks/plugins/path_provider_foundation/darwin"
+  permission_handler_apple:
+    :path: ".symlinks/plugins/permission_handler_apple/ios"
   video_player_avfoundation:
     :path: ".symlinks/plugins/video_player_avfoundation/darwin"
 
 SPEC CHECKSUMS:
+  camera_avfoundation: be3be85408cd4126f250386828e9b1dfa40ab436
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
+  image_gallery_saver_plus: e597bf65a7846979417a3eae0763b71b6dfec6c3
+  image_picker_ios: 7fe1ff8e34c1790d6fff70a32484959f563a928a
   path_provider_foundation: 080d55be775b7414fd5a5ef3ac137b97b097e564
+  permission_handler_apple: 4ed2196e43d0651e8ff7ca3483a069d469701f2d
   video_player_avfoundation: 2cef49524dd1f16c5300b9cd6efd9611ce03639b
 
 PODFILE CHECKSUM: 4305caec6b40dde0ae97be1573c53de1882a07e5

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -199,6 +199,7 @@
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
 				FA0D679610FE3D66ED2D5BC7 /* [CP] Embed Pods Frameworks */,
+				0D7A9A11923D1488923BA631 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -270,6 +271,23 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		0D7A9A11923D1488923BA631 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 		35CF9BF1AC4F54D8FB5CBB39 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -45,5 +45,8 @@
 	<true/>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
+
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>Plz let me see yout photos</string>
 </dict>
 </plist>

--- a/lib/features/videos/video_preview_screen.dart
+++ b/lib/features/videos/video_preview_screen.dart
@@ -46,6 +46,12 @@ class _VideoPreviewScreenState extends State<VideoPreviewScreen> {
     _initVideo();
   }
 
+  @override
+  void dispose() {
+    _videoPlayerController.dispose();
+    super.dispose();
+  }
+
   Future convertTempFileToVideo(String tempFilePath) async {
     final tempFile = File(tempFilePath);
     final fileContent = await tempFile.readAsBytes();

--- a/lib/features/videos/video_recording_screen.dart
+++ b/lib/features/videos/video_recording_screen.dart
@@ -1,4 +1,7 @@
+import 'dart:io';
+
 import 'package:camera/camera.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:image_picker/image_picker.dart';
@@ -19,6 +22,9 @@ class _VideoRecordingScreenState extends State<VideoRecordingScreen>
   bool _hasPermission = false;
 
   bool _isSelfieMode = false;
+
+  // iOS이면 카메라 사용 안하는 걸로 설정
+  late final bool _noCamera = kDebugMode && Platform.isIOS;
 
   late final AnimationController _buttonAnimationController =
       AnimationController(vsync: this, duration: Duration(milliseconds: 200));
@@ -82,7 +88,13 @@ class _VideoRecordingScreenState extends State<VideoRecordingScreen>
   @override
   void initState() {
     super.initState();
-    initPermissions();
+    if (!_noCamera) {
+      initPermissions();
+    } else {
+      setState(() {
+        _hasPermission = true;
+      });
+    }
 
     // 사용자가 앱에서 벗어나면 알려주는 것
     WidgetsBinding.instance.addObserver(this);
@@ -181,7 +193,7 @@ class _VideoRecordingScreenState extends State<VideoRecordingScreen>
       body: SizedBox(
         width: MediaQuery.of(context).size.width,
         child:
-            !_hasPermission || !_cameraController.value.isInitialized
+            !_hasPermission
                 ? Column(
                   crossAxisAlignment: CrossAxisAlignment.center,
                   mainAxisAlignment: MainAxisAlignment.center,
@@ -200,56 +212,59 @@ class _VideoRecordingScreenState extends State<VideoRecordingScreen>
                 : Stack(
                   alignment: Alignment.center,
                   children: [
-                    CameraPreview(_cameraController),
-                    Positioned(
-                      top: Sizes.size20,
-                      right: Sizes.size20,
-                      child: Column(
-                        children: [
-                          IconButton(
-                            color: Colors.white,
-                            onPressed: _toggleSelfieMode,
-                            icon: const Icon(Icons.cameraswitch),
-                          ),
-                          Gaps.v10,
-                          IconButton(
-                            color:
-                                _flashMode == FlashMode.off
-                                    ? Colors.amber.shade200
-                                    : Colors.white,
-                            onPressed: () => _setFlashMode(FlashMode.off),
-                            icon: const Icon(Icons.flash_off_rounded),
-                          ),
-                          Gaps.v10,
-                          IconButton(
-                            color:
-                                _flashMode == FlashMode.always
-                                    ? Colors.amber.shade200
-                                    : Colors.white,
-                            onPressed: () => _setFlashMode(FlashMode.always),
-                            icon: const Icon(Icons.flash_on_rounded),
-                          ),
-                          Gaps.v10,
-                          IconButton(
-                            color:
-                                _flashMode == FlashMode.auto
-                                    ? Colors.amber.shade200
-                                    : Colors.white,
-                            onPressed: () => _setFlashMode(FlashMode.auto),
-                            icon: const Icon(Icons.flash_auto_rounded),
-                          ),
-                          Gaps.v10,
-                          IconButton(
-                            color:
-                                _flashMode == FlashMode.torch
-                                    ? Colors.amber.shade200
-                                    : Colors.white,
-                            onPressed: () => _setFlashMode(FlashMode.torch),
-                            icon: const Icon(Icons.flashlight_on_rounded),
-                          ),
-                        ],
+                    if (!_noCamera && _cameraController.value.isInitialized)
+                      CameraPreview(_cameraController),
+
+                    if (!_noCamera)
+                      Positioned(
+                        top: Sizes.size20,
+                        right: Sizes.size20,
+                        child: Column(
+                          children: [
+                            IconButton(
+                              color: Colors.white,
+                              onPressed: _toggleSelfieMode,
+                              icon: const Icon(Icons.cameraswitch),
+                            ),
+                            Gaps.v10,
+                            IconButton(
+                              color:
+                                  _flashMode == FlashMode.off
+                                      ? Colors.amber.shade200
+                                      : Colors.white,
+                              onPressed: () => _setFlashMode(FlashMode.off),
+                              icon: const Icon(Icons.flash_off_rounded),
+                            ),
+                            Gaps.v10,
+                            IconButton(
+                              color:
+                                  _flashMode == FlashMode.always
+                                      ? Colors.amber.shade200
+                                      : Colors.white,
+                              onPressed: () => _setFlashMode(FlashMode.always),
+                              icon: const Icon(Icons.flash_on_rounded),
+                            ),
+                            Gaps.v10,
+                            IconButton(
+                              color:
+                                  _flashMode == FlashMode.auto
+                                      ? Colors.amber.shade200
+                                      : Colors.white,
+                              onPressed: () => _setFlashMode(FlashMode.auto),
+                              icon: const Icon(Icons.flash_auto_rounded),
+                            ),
+                            Gaps.v10,
+                            IconButton(
+                              color:
+                                  _flashMode == FlashMode.torch
+                                      ? Colors.amber.shade200
+                                      : Colors.white,
+                              onPressed: () => _setFlashMode(FlashMode.torch),
+                              icon: const Icon(Icons.flashlight_on_rounded),
+                            ),
+                          ],
+                        ),
                       ),
-                    ),
                     Positioned(
                       bottom: Sizes.size40,
                       width: MediaQuery.of(context).size.width,


### PR DESCRIPTION
## 20.1 _noCamera

### 화면
<img width="1270" alt="Image" src="https://github.com/user-attachments/assets/fea4293d-3ab9-4487-9afc-e57fa404cd9e" />

### 작업 내역
- [x] iOS 에뮬레이터에서는 카메라가 지원되지 않으므로 iOS 에뮬레이터에서는 카메라 동작을 제거
- [x] 비디오 플레이어 dispose 코드 추가
- [x] iOS 폴더 내부의 `info.plist`파일의 코드를 수정해서 카메라 접근 허용하도록 설정