### PR TITLE
#20.3 Router part Two

### DIFF
--- a/lib/common/widgets/main_navigation/main_navigation_screen.dart
+++ b/lib/common/widgets/main_navigation/main_navigation_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 import 'package:tiktong/constants/gaps.dart';
 import 'package:tiktong/constants/sizes.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
@@ -11,16 +12,31 @@ import 'package:tiktong/features/videos/video_timeline_screen.dart';
 import 'package:tiktong/utils.dart';
 
 class MainNavigationScreen extends StatefulWidget {
-  const MainNavigationScreen({super.key});
+  static const String routeName = "mainNavigation";
+
+  final String tab;
+
+  const MainNavigationScreen({super.key, required this.tab});
 
   @override
   State<MainNavigationScreen> createState() => _MainNavigationScreenState();
 }
 
 class _MainNavigationScreenState extends State<MainNavigationScreen> {
-  int _selectedIndex = 0;
+  final List<String> _tabs = [
+    "home",
+    "discover",
+    //유저가 비디오 찍을 가짜 tab
+    "xxxx",
+    "inbox",
+    "profile",
+  ];
+
+  late int _selectedIndex = _tabs.indexOf(widget.tab);
 
   void _onTap(int index) {
+    context.go("/${_tabs[index]}");
+
     setState(() {
       _selectedIndex = index;
     });

--- a/lib/features/authentication/login_form_screen.dart
+++ b/lib/features/authentication/login_form_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 import 'package:tiktong/constants/gaps.dart';
 import 'package:tiktong/constants/sizes.dart';
 import 'package:tiktong/features/authentication/widgets/form_button.dart';
@@ -22,10 +23,7 @@ class _LoginFormScreenState extends State<LoginFormScreen> {
     if (_formKey.currentState!.validate()) {
       _formKey.currentState!.save();
 
-      Navigator.of(context).pushAndRemoveUntil(
-        MaterialPageRoute(builder: (context) => const InterestsScreen()),
-        (route) => false,
-      );
+      context.goNamed(InterestsScreen.routeName);
     }
   }
 

--- a/lib/features/authentication/login_screen.dart
+++ b/lib/features/authentication/login_screen.dart
@@ -17,9 +17,10 @@ class LoginScreen extends StatelessWidget {
   }
 
   void _onEmailLoginTap(BuildContext context) {
-    Navigator.of(
+    Navigator.push(
       context,
-    ).push(MaterialPageRoute(builder: (context) => const LoginFormScreen()));
+      MaterialPageRoute(builder: (context) => const LoginFormScreen()),
+    );
   }
 
   @override

--- a/lib/features/onboarding/tutorial_screen.dart
+++ b/lib/features/onboarding/tutorial_screen.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 import 'package:tiktong/constants/gaps.dart';
 import 'package:tiktong/constants/sizes.dart';
-import 'package:tiktong/common/widgets/main_navigation/main_navigation_screen.dart';
 
 enum Direction { right, left }
 
@@ -47,10 +47,7 @@ class _TutorialScreenState extends State<TutorialScreen> {
   }
 
   void _onEnterAppTap() {
-    Navigator.of(context).pushAndRemoveUntil(
-      MaterialPageRoute(builder: (context) => MainNavigationScreen()),
-      (route) => false,
-    );
+    context.go("/home");
   }
 
   @override

--- a/lib/router.dart
+++ b/lib/router.dart
@@ -1,4 +1,5 @@
 import 'package:go_router/go_router.dart';
+import 'package:tiktong/common/widgets/main_navigation/main_navigation_screen.dart';
 import 'package:tiktong/features/authentication/login_screen.dart';
 import 'package:tiktong/features/authentication/sign_up_screen.dart';
 import 'package:tiktong/features/onboarding/interests_screen.dart';
@@ -21,6 +22,15 @@ final router = GoRouter(
       name: InterestsScreen.routeName,
       path: InterestsScreen.routeURL,
       builder: (context, state) => InterestsScreen(),
+    ),
+
+    GoRoute(
+      path: "/:tab(home|discover|inbox|profile)",
+      name: MainNavigationScreen.routeName,
+      builder: (context, state) {
+        final tab = state.pathParameters["tab"]!;
+        return MainNavigationScreen(tab: tab);
+      },
     ),
   ],
 );


### PR DESCRIPTION
## 20.3 Router part Two

### 화면
<img width="1271" alt="Image" src="https://github.com/user-attachments/assets/3d9d206c-f27c-4017-9e0d-83235ceb1fd2" />

### 작업 내역
- [x] 메인으로 들어가서 탭으로 이동해야 하는 화면 모두 GoRouter로 전환