### PR TITLE
#20.4 Router part Three

### DIFF
--- a/lib/common/widgets/main_navigation/main_navigation_screen.dart
+++ b/lib/common/widgets/main_navigation/main_navigation_screen.dart
@@ -8,6 +8,7 @@ import 'package:tiktong/features/inbox/inbox_screen.dart';
 import 'package:tiktong/common/widgets/main_navigation/widgets/nav_tab.dart';
 import 'package:tiktong/common/widgets/main_navigation/widgets/post_video_button.dart';
 import 'package:tiktong/features/users/user_profile_screen.dart';
+import 'package:tiktong/features/videos/video_recording_screen.dart';
 import 'package:tiktong/features/videos/video_timeline_screen.dart';
 import 'package:tiktong/utils.dart';
 
@@ -43,14 +44,7 @@ class _MainNavigationScreenState extends State<MainNavigationScreen> {
   }
 
   void _onPostVideoButtonTap() {
-    Navigator.of(context).push(
-      MaterialPageRoute(
-        builder:
-            (context) =>
-                Scaffold(appBar: AppBar(title: const Text('Record video'))),
-        fullscreenDialog: true,
-      ),
-    );
+    context.pushNamed(VideoRecordingScreen.routeName);
   }
 
   @override

--- a/lib/features/inbox/activity_screen.dart
+++ b/lib/features/inbox/activity_screen.dart
@@ -4,6 +4,8 @@ import 'package:tiktong/constants/gaps.dart';
 import 'package:tiktong/constants/sizes.dart';
 
 class ActivityScreen extends StatefulWidget {
+  static const String routeName = "activity";
+  static const String routeURL = "/activity";
   const ActivityScreen({super.key});
 
   @override

--- a/lib/features/inbox/chat_detail_screen.dart
+++ b/lib/features/inbox/chat_detail_screen.dart
@@ -4,7 +4,11 @@ import 'package:tiktong/constants/gaps.dart';
 import 'package:tiktong/constants/sizes.dart';
 
 class ChatDetailScreen extends StatefulWidget {
-  const ChatDetailScreen({super.key});
+  static const String routeName = "chatDetail";
+  static const String routeURL = ":chatId";
+  final String chatId;
+
+  const ChatDetailScreen({super.key, required this.chatId});
 
   @override
   State<ChatDetailScreen> createState() => _ChatDetailScreenState();
@@ -42,7 +46,10 @@ class _ChatDetailScreenState extends State<ChatDetailScreen> {
               ),
             ],
           ),
-          title: Text("인수", style: TextStyle(fontWeight: FontWeight.w600)),
+          title: Text(
+            "인수(${widget.chatId})",
+            style: TextStyle(fontWeight: FontWeight.w600),
+          ),
           subtitle: Text("Active now"),
           trailing: Row(
             mainAxisSize: MainAxisSize.min,

--- a/lib/features/inbox/chats_screen.dart
+++ b/lib/features/inbox/chats_screen.dart
@@ -1,9 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
+import 'package:go_router/go_router.dart';
 import 'package:tiktong/constants/sizes.dart';
 import 'package:tiktong/features/inbox/chat_detail_screen.dart';
 
 class ChatsScreen extends StatefulWidget {
+  static const String routeName = "chats";
+  static const String routeURL = "/chats";
   const ChatsScreen({super.key});
 
   @override
@@ -39,16 +42,17 @@ class _ChatsScreenState extends State<ChatsScreen> {
     }
   }
 
-  void _onChatTap() {
-    Navigator.of(
-      context,
-    ).push(MaterialPageRoute(builder: (context) => const ChatDetailScreen()));
+  void _onChatTap(int index) {
+    context.pushNamed(
+      ChatDetailScreen.routeName,
+      pathParameters: {"chatId": "$index"},
+    );
   }
 
   Widget _makeTile(int index) {
     return ListTile(
       onLongPress: () => _deleteItem(index),
-      onTap: _onChatTap,
+      onTap: () => _onChatTap(index),
       leading: CircleAvatar(
         backgroundColor: Colors.deepPurple,
         radius: 30,

--- a/lib/features/inbox/inbox_screen.dart
+++ b/lib/features/inbox/inbox_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
+import 'package:go_router/go_router.dart';
 import 'package:tiktong/constants/sizes.dart';
 import 'package:tiktong/features/inbox/activity_screen.dart';
 import 'package:tiktong/features/inbox/chats_screen.dart';
@@ -13,15 +14,11 @@ class InBoxScreen extends StatefulWidget {
 
 class _InBoxScreenState extends State<InBoxScreen> {
   void _onDmPressed() {
-    Navigator.of(
-      context,
-    ).push(MaterialPageRoute(builder: (context) => ChatsScreen()));
+    context.pushNamed(ChatsScreen.routeName);
   }
 
   void _onActivityTap(BuildContext context) {
-    Navigator.of(
-      context,
-    ).push(MaterialPageRoute(builder: (context) => const ActivityScreen()));
+    context.pushNamed(ActivityScreen.routeName);
   }
 
   @override

--- a/lib/features/videos/video_recording_screen.dart
+++ b/lib/features/videos/video_recording_screen.dart
@@ -11,6 +11,8 @@ import 'package:tiktong/constants/sizes.dart';
 import 'package:tiktong/features/videos/video_preview_screen.dart';
 
 class VideoRecordingScreen extends StatefulWidget {
+  static const String routeName = 'postVideo';
+  static const String routeURL = "/upload";
   const VideoRecordingScreen({super.key});
 
   @override

--- a/lib/router.dart
+++ b/lib/router.dart
@@ -2,9 +2,15 @@ import 'package:go_router/go_router.dart';
 import 'package:tiktong/common/widgets/main_navigation/main_navigation_screen.dart';
 import 'package:tiktong/features/authentication/login_screen.dart';
 import 'package:tiktong/features/authentication/sign_up_screen.dart';
+import 'package:tiktong/features/inbox/activity_screen.dart';
+import 'package:tiktong/features/inbox/chat_detail_screen.dart';
+import 'package:tiktong/features/inbox/chats_screen.dart';
 import 'package:tiktong/features/onboarding/interests_screen.dart';
+import 'package:tiktong/features/videos/video_recording_screen.dart';
 
 final router = GoRouter(
+  initialLocation: "/inbox",
+
   routes: [
     GoRoute(
       name: SignUpScreen.routeName,
@@ -25,12 +31,40 @@ final router = GoRouter(
     ),
 
     GoRoute(
-      path: "/:tab(home|discover|inbox|profile)",
       name: MainNavigationScreen.routeName,
+      path: "/:tab(home|discover|inbox|profile)",
       builder: (context, state) {
         final tab = state.pathParameters["tab"]!;
         return MainNavigationScreen(tab: tab);
       },
+    ),
+
+    GoRoute(
+      name: ActivityScreen.routeName,
+      path: ActivityScreen.routeURL,
+      builder: (context, state) => ActivityScreen(),
+    ),
+
+    GoRoute(
+      name: ChatsScreen.routeName,
+      path: ChatsScreen.routeURL,
+      builder: (context, state) => ChatsScreen(),
+      routes: [
+        GoRoute(
+          name: ChatDetailScreen.routeName,
+          path: ChatDetailScreen.routeURL,
+          builder: (context, state) {
+            final chatId = state.pathParameters["chatId"]!;
+            return ChatDetailScreen(chatId: chatId);
+          },
+        ),
+      ],
+    ),
+
+    GoRoute(
+      name: VideoRecordingScreen.routeName,
+      path: VideoRecordingScreen.routeURL,
+      builder: (context, state) => VideoRecordingScreen(),
     ),
   ],
 );


### PR DESCRIPTION
## 20.4 Router part Three

### 화면
<img width="1272" alt="Image" src="https://github.com/user-attachments/assets/f87fc93f-4311-4305-b676-abf6487f0a82" />


### 작업 내역
- [x] `Inbox`탭에 있는 화면을 GoRouter로 전환
- [x] 채팅방 화면에서 채팅 화면으로 전환시 GoRouter 에서 Nested Route 설정을 통해 접근하도록 수정