### PR TITLE
#20.5 Router part Four

### DIFF
--- a/lib/features/videos/video_recording_screen.dart
+++ b/lib/features/videos/video_recording_screen.dart
@@ -157,12 +157,15 @@ class _VideoRecordingScreenState extends State<VideoRecordingScreen>
   void dispose() {
     _progressAnimationController.dispose();
     _buttonAnimationController.dispose();
-    _cameraController.dispose();
+    if (!_noCamera) {
+      _cameraController.dispose();
+    }
     super.dispose();
   }
 
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (_noCamera) return;
     if (!_hasPermission) return;
     if (!_cameraController.value.isInitialized) return;
 
@@ -216,6 +219,12 @@ class _VideoRecordingScreenState extends State<VideoRecordingScreen>
                   children: [
                     if (!_noCamera && _cameraController.value.isInitialized)
                       CameraPreview(_cameraController),
+
+                    Positioned(
+                      top: Sizes.size40,
+                      left: Sizes.size20,
+                      child: CloseButton(color: Colors.white),
+                    ),
 
                     if (!_noCamera)
                       Positioned(

--- a/lib/router.dart
+++ b/lib/router.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/cupertino.dart';
 import 'package:go_router/go_router.dart';
 import 'package:tiktong/common/widgets/main_navigation/main_navigation_screen.dart';
 import 'package:tiktong/features/authentication/login_screen.dart';
@@ -64,7 +65,20 @@ final router = GoRouter(
     GoRoute(
       name: VideoRecordingScreen.routeName,
       path: VideoRecordingScreen.routeURL,
-      builder: (context, state) => VideoRecordingScreen(),
+      pageBuilder: (context, state) {
+        return CustomTransitionPage(
+          transitionDuration: Duration(milliseconds: 200),
+          child: VideoRecordingScreen(),
+          transitionsBuilder: (context, animation, secondaryAnimation, child) {
+            final position = Tween(
+              begin: Offset(0, 1),
+              end: Offset.zero,
+            ).animate(animation);
+
+            return SlideTransition(position: position, child: child);
+          },
+        );
+      },
     ),
   ],
 );


### PR DESCRIPTION
## 20.5 Router part Four

### 화면
![Image](https://github.com/user-attachments/assets/1f1db089-e307-4e92-952e-72bd4645cc70)

### 작업 내역
- [x] 가운데 탭을 누르면 비디오 녹화 화면으로 전환
- [x] 비디오 녹화 화면 전환이 아래에서 위로 되도록 설정
- [x] 비디오 녹화 화면에 `X` 버튼을 추가해 누르면 이전화면으로 돌아가도록 설정