### PR TITLE
#20.7 InheritedWidget part Two

### DIFF
--- a/lib/common/widgets/video_configuration/video_config.dart
+++ b/lib/common/widgets/video_configuration/video_config.dart
@@ -1,18 +1,53 @@
 import 'package:flutter/widgets.dart';
 
-class VideoConfig extends InheritedWidget {
-  const VideoConfig({super.key, required super.child});
+class VideoConfigData extends InheritedWidget {
+  final bool autoMute;
 
-  final bool autoMute = false;
+  final void Function() toggleMuted;
 
-  static VideoConfig of(BuildContext context) {
-    // VideoConfig라는 타입의 InheritedWidget을 가져오라고 context에 명령
-    return context.dependOnInheritedWidgetOfExactType<VideoConfig>()!;
+  const VideoConfigData({
+    super.key,
+    required super.child,
+    required this.autoMute,
+    required this.toggleMuted,
+  });
+
+  static VideoConfigData of(BuildContext context) {
+    // VideoConfigData라는 타입의 InheritedWidget을 가져오라고 context에 명령
+    return context.dependOnInheritedWidgetOfExactType<VideoConfigData>()!;
   }
 
   // 위젯을 rebuild 할지 말지를 정할 수 있게 도와줌
   @override
   bool updateShouldNotify(covariant InheritedWidget oldWidget) {
     return true;
+  }
+}
+
+class VideoConfig extends StatefulWidget {
+  final Widget child;
+
+  const VideoConfig({super.key, required this.child});
+
+  @override
+  State<VideoConfig> createState() => _VideoConfigState();
+}
+
+class _VideoConfigState extends State<VideoConfig> {
+  bool autoMute = false;
+
+  void toggleMuted() {
+    setState(() {
+      autoMute = !autoMute;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return VideoConfigData(
+      autoMute: autoMute,
+      toggleMuted: toggleMuted,
+      child: widget.child,
+    );
   }
 }

--- a/lib/features/settings/settings_screen.dart
+++ b/lib/features/settings/settings_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
+import 'package:tiktong/common/widgets/video_configuration/video_config.dart';
 
 class SettingsScreen extends StatefulWidget {
   const SettingsScreen({super.key});
@@ -113,9 +114,11 @@ class _SettingsScreenState extends State<SettingsScreen> {
         body: ListView(
           children: [
             SwitchListTile.adaptive(
-              value: _notifications,
-              onChanged: _onNotificationsChanged,
-              title: Text("Enable notifications"),
+              value: VideoConfigData.of(context).autoMute,
+              onChanged: (value) {
+                VideoConfigData.of(context).toggleMuted();
+              },
+              title: Text("Auto Mute videos"),
               subtitle: Text("Enable notifications"),
             ),
 
@@ -123,7 +126,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
               activeColor: Colors.black,
               value: _notifications,
               onChanged: _onNotificationsChanged,
-              title: Text("Enable notifications"),
+              title: Text("Videos will be muted by default."),
             ),
 
             ListTile(

--- a/lib/features/videos/widgets/video_post.dart
+++ b/lib/features/videos/widgets/video_post.dart
@@ -187,12 +187,12 @@ class _VideoPostState extends State<VideoPost>
             top: Sizes.size40,
             child: IconButton(
               icon: FaIcon(
-                VideoConfig.of(context).autoMute
+                VideoConfigData.of(context).autoMute
                     ? FontAwesomeIcons.volumeOff
                     : FontAwesomeIcons.volumeHigh,
                 color: Colors.white,
               ),
-              onPressed: () {},
+              onPressed: VideoConfigData.of(context).toggleMuted,
             ),
           ),
 


### PR DESCRIPTION
## 20.7 InheritedWidget part Two

### 화면
<img width="1272" alt="Image" src="https://github.com/user-attachments/assets/84e1f382-b7fc-4177-bf20-e0506a6a04fd" />

### 작업내역
- [x] Statefule Widget + Inherited Widget 을 이용해서 Settings 화면과 Home 화면 전체 음소거가 상태를 공유하도록 기능 구현 