### PR TITLE
#22.4 AsyncNotifierProvider

### DIFF
--- a/lib/features/videos/models/video_model.dart
+++ b/lib/features/videos/models/video_model.dart
@@ -1,0 +1,4 @@
+class VideoModel {
+  String title;
+  VideoModel({required this.title});
+}

--- a/lib/features/videos/view_models/timeline_view_model.dart
+++ b/lib/features/videos/view_models/timeline_view_model.dart
@@ -1,0 +1,37 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:tiktong/features/videos/models/video_model.dart';
+
+class TimelineViewModel extends AsyncNotifier<List<VideoModel>> {
+  List<VideoModel> _list = [VideoModel(title: "First video")];
+
+  void uploadVideo() async {
+    // timeline view model을 다시 loading state로 변경
+    state = AsyncValue.loading();
+
+    // 2초 딜레이
+    await Future.delayed(const Duration(seconds: 2));
+
+    final newVideo = VideoModel(title: "${DateTime.now()}");
+    _list = [..._list, newVideo];
+    state = AsyncValue.data(_list);
+  }
+
+  @override
+  FutureOr<List<VideoModel>> build() async {
+    // 5초 딜레이
+    await Future.delayed(Duration(seconds: 5));
+
+    // 에러출력 테스트
+    // throw Exception("OMG cant fetch");
+
+    return _list;
+  }
+}
+
+// AsyncNotifierProvider<expose할 Notifier, 화면에 전달할 데이터>(View Model을 초기화 해줄 function);
+final timelineProvider =
+    AsyncNotifierProvider<TimelineViewModel, List<VideoModel>>(
+      () => TimelineViewModel(),
+    );

--- a/lib/features/videos/views/video_preview_screen.dart
+++ b/lib/features/videos/views/video_preview_screen.dart
@@ -2,11 +2,13 @@ import 'dart:io';
 
 import 'package:camera/camera.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:image_gallery_saver_plus/image_gallery_saver_plus.dart';
+import 'package:tiktong/features/videos/view_models/timeline_view_model.dart';
 import 'package:video_player/video_player.dart';
 
-class VideoPreviewScreen extends StatefulWidget {
+class VideoPreviewScreen extends ConsumerStatefulWidget {
   final XFile video;
 
   final bool isPicked;
@@ -18,10 +20,10 @@ class VideoPreviewScreen extends StatefulWidget {
   });
 
   @override
-  State<VideoPreviewScreen> createState() => _VideoPreviewScreenState();
+  VideoPreviewScreenState createState() => VideoPreviewScreenState();
 }
 
-class _VideoPreviewScreenState extends State<VideoPreviewScreen> {
+class VideoPreviewScreenState extends ConsumerState<VideoPreviewScreen> {
   late final VideoPlayerController _videoPlayerController;
 
   bool _savedVideo = false;
@@ -83,8 +85,14 @@ class _VideoPreviewScreenState extends State<VideoPreviewScreen> {
     setState(() {});
   }
 
+  void _onUploadPressed() {
+    ref.read(timelineProvider.notifier).uploadVideo();
+  }
+
   @override
   Widget build(BuildContext context) {
+    final isLoading = ref.watch(timelineProvider).isLoading;
+
     return Scaffold(
       backgroundColor: Colors.black,
       appBar: AppBar(
@@ -99,6 +107,14 @@ class _VideoPreviewScreenState extends State<VideoPreviewScreen> {
                     : FontAwesomeIcons.download,
               ),
             ),
+
+          IconButton(
+            onPressed: isLoading ? () {} : _onUploadPressed,
+            icon:
+                isLoading
+                    ? const CircularProgressIndicator()
+                    : const FaIcon(FontAwesomeIcons.cloudArrowUp),
+          ),
         ],
       ),
       body:

--- a/lib/features/videos/views/video_timeline_screen.dart
+++ b/lib/features/videos/views/video_timeline_screen.dart
@@ -1,14 +1,16 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:tiktong/features/videos/view_models/timeline_view_model.dart';
 import 'package:tiktong/features/videos/views/widgets/video_post.dart';
 
-class VideoTimelineScreen extends StatefulWidget {
+class VideoTimelineScreen extends ConsumerStatefulWidget {
   const VideoTimelineScreen({super.key});
 
   @override
-  State<VideoTimelineScreen> createState() => _VideoTimelineScreenState();
+  VideoTimelineScreenState createState() => VideoTimelineScreenState();
 }
 
-class _VideoTimelineScreenState extends State<VideoTimelineScreen> {
+class VideoTimelineScreenState extends ConsumerState<VideoTimelineScreen> {
   int _itemCount = 4;
 
   final PageController _pageController = PageController();
@@ -42,19 +44,34 @@ class _VideoTimelineScreenState extends State<VideoTimelineScreen> {
 
   @override
   Widget build(BuildContext context) {
-    return RefreshIndicator(
-      onRefresh: _onRefresh,
-      edgeOffset: 20,
-      displacement: 50,
-      child: PageView.builder(
-        controller: _pageController,
-        scrollDirection: Axis.vertical,
-        onPageChanged: _onPageChanged,
-        itemCount: _itemCount,
-        itemBuilder:
-            (context, index) =>
-                VideoPost(onVideoFinished: _onVideoFinished, index: index),
-      ),
-    );
+    return ref
+        .watch(timelineProvider)
+        .when(
+          loading: () => Center(child: CircularProgressIndicator()),
+          error:
+              (error, stackTrace) => Center(
+                child: Text(
+                  "Could not load videos: $error",
+                  style: const TextStyle(color: Colors.white),
+                ),
+              ),
+          data:
+              (videos) => RefreshIndicator(
+                onRefresh: _onRefresh,
+                edgeOffset: 20,
+                displacement: 50,
+                child: PageView.builder(
+                  controller: _pageController,
+                  scrollDirection: Axis.vertical,
+                  onPageChanged: _onPageChanged,
+                  itemCount: videos.length,
+                  itemBuilder:
+                      (context, index) => VideoPost(
+                        onVideoFinished: _onVideoFinished,
+                        index: index,
+                      ),
+                ),
+              ),
+        );
   }
 }


### PR DESCRIPTION
## 22.4 AsyncNotifierProvider

### 화면
![Image](https://github.com/user-attachments/assets/ae3c8f4b-6c7a-460f-993a-9dcb70ac1a85)

### 작업 내역
- [x] 가운데 `+` 버튼 탭으로 들어가서 사진아이콘을 클릭해서 나오는 기기의 갤러리에 있는 영상을 터치 시 프리뷰로 열리는데 이 프리뷰 화면에서 우측 상단에 업로드 버튼을 추가해서 기존에 Home 화면에서 불러오는 비디오 리스트에 추가하도록 기능 구현
- [x] 이후 Firebase 연동을 위해 `AsyncNotifierProvider`로 비디오 데이터 불러오는 로딩 상태를 추가